### PR TITLE
Raise ValueError when no choices are provided in select prompt.

### DIFF
--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -57,6 +57,8 @@ def select(message: Text,
     Returns:
         Question: Question instance, ready to be prompted (using `.ask()`).
     """
+    if choices is None or len(choices) == 0:
+        raise ValueError('A list of choices needs to be provided.')
 
     if use_shortcuts and len(choices) > len(InquirerControl.SHORTCUT_KEYS):
         raise ValueError('A list with shortcuts supports a maximum of {} '

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -114,3 +114,14 @@ def test_select_ctr_c():
 
     with pytest.raises(KeyboardInterrupt):
         feed_cli_with_input('select', message, text, **kwargs)
+
+
+def test_select_empty_choices():
+    message = 'Foo message'
+    kwargs = {
+        'choices': []
+    }
+    text = KeyInputs.ENTER + "\r"
+
+    with pytest.raises(ValueError):
+        feed_cli_with_input('select', message, text, **kwargs)


### PR DESCRIPTION
When you leave your choices empty (aka `choices=[]`), the program crashes and some funky stuff happens.
This prevents that :)

Right now it just raises the ValueError, but I was looking for the correct place to catch the exception and output a human-readable message like you do for the other exceptions, but couldn't find it.
If you could point me in the right direction, that'd be great.