### PR TITLE
Add highlight style for pointed-at item

### DIFF
--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -204,15 +204,15 @@ class InquirerControl(FormattedTextControl):
                 if index == self.pointed_at:
                     tokens.append(("class:highlighted",
                                    "{}{}".format(shortcut,
-                                                   choice.title)))
+                                                 choice.title)))
                 elif selected:
                     tokens.append(("class:selected",
                                    "{}{}".format(shortcut,
-                                                   choice.title)))
+                                                 choice.title)))
                 else:
                     tokens.append(("",
                                    "{}{}".format(shortcut,
-                                                   choice.title)))
+                                                 choice.title)))
 
             tokens.append(("", "\n"))
 

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -191,9 +191,7 @@ class InquirerControl(FormattedTextControl):
                         indicator = ""
 
                     tokens.append(("class:selected",
-                                   "{}{}{}".format(indicator,
-                                                   shortcut,
-                                                   choice.title)))
+                                   "{}".format(indicator)))
                 else:
                     if self.use_indicator:
                         indicator = INDICATOR_UNSELECTED + " "
@@ -201,8 +199,19 @@ class InquirerControl(FormattedTextControl):
                         indicator = ""
 
                     tokens.append(("",
-                                   "{}{}{}".format(indicator,
-                                                   shortcut,
+                                   "{}".format(indicator)))
+
+                if index == self.pointed_at:
+                    tokens.append(("class:highlighted",
+                                   "{}{}".format(shortcut,
+                                                   choice.title)))
+                elif selected:
+                    tokens.append(("class:selected",
+                                   "{}{}".format(shortcut,
+                                                   choice.title)))
+                else:
+                    tokens.append(("",
+                                   "{}{}".format(shortcut,
                                                    choice.title)))
 
             tokens.append(("", "\n"))


### PR DESCRIPTION
Added a token for the pointed-at item in list style controls. This was possible in PyInquirer and I like the look of it better than the pointer. The new style token is called `highlighted`.

Signed-off-by: Michael Murton <6764025+CrazyIvan359@users.noreply.github.com>