### PR TITLE
Make pointer optional in list controls

### DIFF
--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -25,6 +25,7 @@ def checkbox(message: Text,
              default: Optional[Text] = None,
              qmark: Text = DEFAULT_QUESTION_PREFIX,
              style: Optional[Style] = None,
+             use_pointer: bool = True,
              **kwargs: Any) -> Question:
     """Ask the user to select from a list of items.
 
@@ -48,13 +49,17 @@ def checkbox(message: Text,
         style: A custom color and style for the question parts. You can
                configure colors as well as font types for different elements.
 
+        use_pointer: Flag to enable the pointer in front of the currently
+                     highlighted element.
+
     Returns:
         Question: Question instance, ready to be prompted (using `.ask()`).
     """
 
     merged_style = merge_styles([DEFAULT_STYLE, style])
 
-    ic = InquirerControl(choices, default)
+    ic = InquirerControl(choices, default,
+                         use_pointer=use_pointer)
 
     def get_prompt_tokens():
         tokens = []

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -91,10 +91,12 @@ class InquirerControl(FormattedTextControl):
                  default: Optional[Any] = None,
                  use_indicator: bool = True,
                  use_shortcuts: bool = False,
+                 use_pointer: bool = True,
                  **kwargs):
 
         self.use_indicator = use_indicator
         self.use_shortcuts = use_shortcuts
+        self.use_pointer = use_pointer
         self.default = default
 
         self.pointed_at = None
@@ -166,8 +168,12 @@ class InquirerControl(FormattedTextControl):
             selected = (choice.value in self.selected_options)
 
             if index == self.pointed_at:
-                tokens.append(("class:pointer",
-                               " {} ".format(SELECTED_POINTER)))
+                if self.use_pointer:
+                    tokens.append(("class:pointer",
+                                " {} ".format(SELECTED_POINTER)))
+                else:
+                    tokens.append(("", "   "))
+
                 tokens.append(("[SetCursorPosition]", ""))
             else:
                 tokens.append(("", "   "))

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -29,6 +29,7 @@ def select(message: Text,
            style: Optional[Style] = None,
            use_shortcuts: bool = False,
            use_indicator: bool = False,
+           use_pointer: bool = True,
            **kwargs: Any) -> Question:
     """Prompt the user to select one item from the list of choices.
 
@@ -57,6 +58,9 @@ def select(message: Text,
         use_shortcuts: Allow the user to select items from the list using
                        shortcuts. The shortcuts will be displayed in front of
                        the list items.
+
+        use_pointer: Flag to enable the pointer in front of the currently
+                     highlighted element.
     Returns:
         Question: Question instance, ready to be prompted (using `.ask()`).
     """
@@ -75,7 +79,8 @@ def select(message: Text,
 
     ic = InquirerControl(choices, default,
                          use_indicator=use_indicator,
-                         use_shortcuts=use_shortcuts)
+                         use_shortcuts=use_shortcuts,
+                         use_pointer=use_pointer)
 
     def get_prompt_tokens():
         # noinspection PyListCreation


### PR DESCRIPTION
As mentioned in #12 I prefer the look of the pointed-at item being a different style rather that having a pointer beside it, this adds a flag to allow disabling the pointer symbol in list style controls.

I originally thought that `use_indicator` would serve this purpose, but for `select` it turns on the `checkbox` style checkbox symbol. I suggest removing this option from the `select` prompt as well, but I wanted to discuss before making that change.
https://github.com/tmbo/questionary/blob/da7a2f9687d09e1eb7abbfb5500ff028634b3c4b/questionary/prompts/select.py#L53-L55

Signed-off-by: Michael Murton <6764025+CrazyIvan359@users.noreply.github.com>