### PR TITLE
Add additional styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Python library to build pretty command line user prompts ✨
 
 You need input from a user, e.g. how an output file should be named or if he really wants to execute that dangerous operation? This library will help you make the input prompts easy to read and answer for the user.
 
-Used and Supported by: 
+Used and Supported by:
 
 [<img src="https://rasa.com/docs/_static/rasa_logo.svg" width="60">](https://github.com/RasaHQ/rasa)
 
@@ -49,9 +49,9 @@ This will create the following list, allowing the user to choose an option:
 ### Different question types
 
 <details><summary>text</summary>
-    
-   A free text input for the user. 
-    
+
+   A free text input for the user.
+
    ```python
    questionary.text("What's your first name").ask()
    ```
@@ -61,23 +61,23 @@ This will create the following list, allowing the user to choose an option:
 <details><summary>password</summary>
 
    A free text input for the user where the input is not
-   shown but replaced with `***`. 
-    
+   shown but replaced with `***`.
+
    ```python
    questionary.password("What's your secret?").ask()
    ```
-   
+
    <img src="docs/images/password.png" width="500">
 
 </details>
 <details><summary>confirm</summary>
 
-   A yes or no question. The user can either confirm or deny. 
-    
+   A yes or no question. The user can either confirm or deny.
+
    ```python
    questionary.confirm("Are you amazed?").ask()
    ```
-   
+
    <img src="docs/images/confirm.png" width="500">
 
 </details>
@@ -85,7 +85,7 @@ This will create the following list, allowing the user to choose an option:
 
    A list of items to select a choice from. The user can pick
    one option and confirm it.
-    
+
    ```python
    questionary.select(
        "What do you want to do?",
@@ -95,7 +95,7 @@ This will create the following list, allowing the user to choose an option:
            "Ask for opening hours"
        ]).ask()
    ```
-   
+
    <img src="docs/images/select.png" width="500">
 
 </details>
@@ -140,8 +140,8 @@ This will create the following list, allowing the user to choose an option:
 <details><summary>Skipping questions using conditions</summary>
 
 Sometimes it is helpfull to e.g. provide a command line flag to your app
-to skip any prompts, to avoid the need for an if around any question you 
-can pass that flag when you create the question: 
+to skip any prompts, to avoid the need for an if around any question you
+can pass that flag when you create the question:
 
 ```python
 DISABLED = True
@@ -150,13 +150,13 @@ response = questionary.confirm("Are you amazed?").skip_if(DISABLED, default=True
 ```
 
 If the condition (in this case `DISABLED`) is `True`, the question will be
-skipped and the default value gets returned, otherwise the user will be 
+skipped and the default value gets returned, otherwise the user will be
 prompted as usual and the default value will be ignored.
 </details>
 
 <details><summary>Alterative style to create questions using a configuration dictionary</summary>
 
-Instead of creating questions using the python functions, you can also create them using a configuration dictionary. 
+Instead of creating questions using the python functions, you can also create them using a configuration dictionary.
 ```python
 questions = [
     {
@@ -185,13 +185,16 @@ You can customize all the colors used for the prompts. Every part of the prompt 
 from prompt_toolkit.styles import Style
 
 custom_style_fancy = Style([
-    ('qmark', 'fg:#673ab7 bold'),     # token in front of the question
-    ('question', 'bold'),             # question text
-    ('answer', 'fg:#f44336 bold'),    # submitted answer text behind the question
-    ('pointer', 'fg:#673ab7 bold'),   # pointer used in select and checkbox prompts
-    ('selected', 'fg:#cc5454'),       # style for a selected item of a checkbox
-    ('separator', 'fg:#cc5454'),      # separator in lists
-    ('instruction', '')               # user instructions for select, rawselect, checkbox
+    ('qmark', 'fg:#673ab7 bold'),       # token in front of the question
+    ('question', 'bold'),               # question text
+    ('answer', 'fg:#f44336 bold'),      # submitted answer text behind the question
+    ('pointer', 'fg:#673ab7 bold'),     # pointer used in select and checkbox prompts
+    ('highlighted', 'fg:#673ab7 bold'), # pointed-at choice in select and checkbox prompts if use_pointer=False
+    ('selected', 'fg:#cc5454'),         # style for a selected item of a checkbox
+    ('separator', 'fg:#cc5454'),        # separator in lists
+    ('instruction', ''),                # user instructions for select, rawselect, checkbox
+    ('text', ''),                       # plain text
+    ('disabled', 'fg:#858585 italic')   # disabled choices for select and checkbox prompts
 ])
 ```
 
@@ -199,6 +202,22 @@ To use our custom style, we need to pass it to the question type:
 ```python
 questionary.text("What's your phone number", style=custom_style_fancy).ask()
 ```
+
+It is also possible to use a list of token tuples as a `Choice` title. This
+example assumes there is a style token named `bold` in the custom style you are
+using:
+```python
+Choice(
+    title=[
+        ('class:text', 'plain text '),
+        ('class:bold', 'bold text')
+    ]
+)
+```
+As you can see it is possible to use custom style tokens for this purpose as
+well. Note that Choices with token tuple titles will not be styled by the
+`selected` or `highlighted` tokens. If not provided, the `value` of the Choice
+will be the text concatenated (`'plain text bold text'` in the above example).
 </details>
 
 ## How to Contribute
@@ -215,12 +234,12 @@ questionary.text("What's your phone number", style=custom_style_fancy).ask()
     works as expected.
 4.  Send a pull request and bug the maintainer until it gets merged and
     published. 🙂
-    
+
 ## Contributors
 
-`questionary` is written and maintained by Tom Bocklisch. 
+`questionary` is written and maintained by Tom Bocklisch.
 
-It is based on the great work of [Oyetoke Toby](https://github.com/CITGuru/PyInquirer) as well as the work from [Mark Fink](https://github.com/finklabs/whaaaaat). 
+It is based on the great work of [Oyetoke Toby](https://github.com/CITGuru/PyInquirer) as well as the work from [Mark Fink](https://github.com/finklabs/whaaaaat).
 
 ## Changelog
 

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -6,7 +6,10 @@ custom_style_fancy = Style([
     ('question', ''),
     ('selected', 'fg:#cc5454'),
     ('pointer', 'fg:#673ab7 bold'),
+    ('highlighted', 'fg:#673ab7 bold'),
     ('answer', 'fg:#f44336 bold'),
+    ('text', ''),
+    ('disabled', 'fg:#858585 italic'),
 ])
 
 custom_style_dope = Style([

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -25,6 +25,7 @@ def checkbox(message: Text,
              default: Optional[Text] = None,
              qmark: Text = DEFAULT_QUESTION_PREFIX,
              style: Optional[Style] = None,
+             use_pointer: bool = True,
              **kwargs: Any) -> Question:
     """Ask the user to select from a list of items.
 
@@ -48,13 +49,17 @@ def checkbox(message: Text,
         style: A custom color and style for the question parts. You can
                configure colors as well as font types for different elements.
 
+        use_pointer: Flag to enable the pointer in front of the currently
+                     highlighted element.
+
     Returns:
         Question: Question instance, ready to be prompted (using `.ask()`).
     """
 
     merged_style = merge_styles([DEFAULT_STYLE, style])
 
-    ic = InquirerControl(choices, default)
+    ic = InquirerControl(choices, default,
+                         use_pointer=use_pointer)
 
     def get_prompt_tokens():
         tokens = []

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -71,9 +71,14 @@ def checkbox(message: Text,
             if nbr_selected == 0:
                 tokens.append(("class:answer", ' done'))
             elif nbr_selected == 1:
-                tokens.append(("class:answer",
-                               ' [{}]'.format(
-                                   ic.get_selected_values()[0].title)))
+                if isinstance(ic.get_selected_values()[0].title, list):
+                    tokens.append(("class:answer",
+                                   "".join([token[1] for token in
+                                       ic.get_selected_values()[0].title])))
+                else:
+                    tokens.append(("class:answer",
+                                   ' [{}]'.format(
+                                       ic.get_selected_values()[0].title)))
             else:
                 tokens.append(("class:answer",
                                ' done ({} selections)'.format(

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -74,7 +74,7 @@ def checkbox(message: Text,
                 if isinstance(ic.get_selected_values()[0].title, list):
                     tokens.append(("class:answer",
                                    "".join([token[1] for token in
-                                       ic.get_selected_values()[0].title])))
+                                           ic.get_selected_values()[0].title])))
                 else:
                     tokens.append(("class:answer",
                                    ' [{}]'.format(

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -197,9 +197,7 @@ class InquirerControl(FormattedTextControl):
                         indicator = ""
 
                     tokens.append(("class:selected",
-                                   "{}{}{}".format(indicator,
-                                                   shortcut,
-                                                   choice.title)))
+                                   "{}".format(indicator)))
                 else:
                     if self.use_indicator:
                         indicator = INDICATOR_UNSELECTED + " "
@@ -207,9 +205,20 @@ class InquirerControl(FormattedTextControl):
                         indicator = ""
 
                     tokens.append(("",
-                                   "{}{}{}".format(indicator,
-                                                   shortcut,
-                                                   choice.title)))
+                                   "{}".format(indicator)))
+
+                if index == self.pointed_at:
+                    tokens.append(("class:highlighted",
+                                   "{}{}".format(shortcut,
+                                                 choice.title)))
+                elif selected:
+                    tokens.append(("class:selected",
+                                   "{}{}".format(shortcut,
+                                                 choice.title)))
+                else:
+                    tokens.append(("",
+                                   "{}{}".format(shortcut,
+                                                 choice.title)))
 
             tokens.append(("", "\n"))
 

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -172,11 +172,11 @@ class InquirerControl(FormattedTextControl):
                     tokens.append(("class:pointer",
                                    " {} ".format(SELECTED_POINTER)))
                 else:
-                    tokens.append(("", "   "))
+                    tokens.append(("class:text", "   "))
 
                 tokens.append(("[SetCursorPosition]", ""))
             else:
-                tokens.append(("", "   "))
+                tokens.append(("class:text", "   "))
 
             if isinstance(choice, Separator):
                 tokens.append(("class:separator", "{}".format(choice.title)))
@@ -204,7 +204,7 @@ class InquirerControl(FormattedTextControl):
                     else:
                         indicator = ""
 
-                    tokens.append(("",
+                    tokens.append(("class:text",
                                    "{}".format(indicator)))
 
                 if index == self.pointed_at:
@@ -216,7 +216,7 @@ class InquirerControl(FormattedTextControl):
                                    "{}{}".format(shortcut,
                                                  choice.title)))
                 else:
-                    tokens.append(("",
+                    tokens.append(("class:text",
                                    "{}{}".format(shortcut,
                                                  choice.title)))
 
@@ -227,7 +227,7 @@ class InquirerControl(FormattedTextControl):
             append(i, c)
 
         if self.use_shortcuts:
-            tokens.append(("",
+            tokens.append(("class:text",
                            '  Answer: {}'
                            ''.format(self.get_pointed_at().shortcut_key)))
         else:

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -182,15 +182,19 @@ class InquirerControl(FormattedTextControl):
                 tokens.append(("class:separator", "{}".format(choice.title)))
             elif choice.disabled:  # disabled
                 if isinstance(choice.title, list):
-                    tokens.append(("class:selected" if selected else "class:disabled", "- "))
+                    tokens.append(("class:selected" if selected
+                                   else "class:disabled", "- "))
                     tokens.extend(choice.title)
                 else:
-                    tokens.append(("class:selected" if selected else "class:disabled",
+                    tokens.append(("class:selected" if selected
+                                   else "class:disabled",
                                    "- {}".format(choice.title)))
 
-                tokens.append(("class:selected" if selected else "class:disabled",
-                               "{}".format("" if isinstance(choice.disabled, bool)
-                                           else " ({})".format(choice.disabled))))
+                tokens.append(("class:selected" if selected
+                               else "class:disabled",
+                               "{}".format(
+                                   "" if isinstance(choice.disabled, bool)
+                                   else " ({})".format(choice.disabled))))
             else:
                 if self.use_shortcuts and choice.shortcut_key is not None:
                     shortcut = "{}) ".format(choice.shortcut_key)

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -181,10 +181,16 @@ class InquirerControl(FormattedTextControl):
             if isinstance(choice, Separator):
                 tokens.append(("class:separator", "{}".format(choice.title)))
             elif choice.disabled:  # disabled
+                if isinstance(choice.title, list):
+                    tokens.append(("class:selected" if selected else "class:disabled", "- "))
+                    tokens.extend(choice.title)
+                else:
+                    tokens.append(("class:selected" if selected else "class:disabled",
+                                   "- {}".format(choice.title)))
+
                 tokens.append(("class:selected" if selected else "class:disabled",
-                               "- {}{}".format(choice.title,
-                                               "" if isinstance(choice.disabled, bool)
-                                               else " ({})".format(choice.disabled))))
+                               "{}".format("" if isinstance(choice.disabled, bool)
+                                           else " ({})".format(choice.disabled))))
             else:
                 if self.use_shortcuts and choice.shortcut_key is not None:
                     shortcut = "{}) ".format(choice.shortcut_key)
@@ -208,7 +214,9 @@ class InquirerControl(FormattedTextControl):
                     tokens.append(("class:text",
                                    "{}".format(indicator)))
 
-                if index == self.pointed_at:
+                if isinstance(choice.title, list):
+                    tokens.extend(choice.title)
+                elif index == self.pointed_at and not self.use_pointer:
                     tokens.append(("class:highlighted",
                                    "{}{}".format(shortcut,
                                                  choice.title)))

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -39,9 +39,15 @@ class Choice(object):
         """
 
         self.disabled = disabled
-        self.value = value if value is not None else title
         self.title = title
         self.checked = checked
+
+        if value is not None:
+            self.value = value
+        elif isinstance(title, list):
+            self.value = "".join([token[1] for token in title])
+        else:
+            self.value = title
 
         if shortcut_key is not None:
             self.shortcut_key = str(shortcut_key)

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -182,8 +182,9 @@ class InquirerControl(FormattedTextControl):
                 tokens.append(("class:separator", "{}".format(choice.title)))
             elif choice.disabled:  # disabled
                 tokens.append(("class:selected" if selected else "class:disabled",
-                               "- {} ({})".format(choice.title,
-                                                  choice.disabled)))
+                               "- {}{}".format(choice.title,
+                                               "" if isinstance(choice.disabled, bool)
+                                               else " ({})".format(choice.disabled))))
             else:
                 if self.use_shortcuts and choice.shortcut_key is not None:
                     shortcut = "{}) ".format(choice.shortcut_key)

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -181,7 +181,7 @@ class InquirerControl(FormattedTextControl):
             if isinstance(choice, Separator):
                 tokens.append(("class:separator", "{}".format(choice.title)))
             elif choice.disabled:  # disabled
-                tokens.append(("class:selected" if selected else "",
+                tokens.append(("class:selected" if selected else "class:disabled",
                                "- {} ({})".format(choice.title,
                                                   choice.disabled)))
             else:

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -91,10 +91,12 @@ class InquirerControl(FormattedTextControl):
                  default: Optional[Any] = None,
                  use_indicator: bool = True,
                  use_shortcuts: bool = False,
+                 use_pointer: bool = True,
                  **kwargs):
 
         self.use_indicator = use_indicator
         self.use_shortcuts = use_shortcuts
+        self.use_pointer = use_pointer
         self.default = default
 
         self.pointed_at = None
@@ -166,8 +168,12 @@ class InquirerControl(FormattedTextControl):
             selected = (choice.value in self.selected_options)
 
             if index == self.pointed_at:
-                tokens.append(("class:pointer",
-                               " {} ".format(SELECTED_POINTER)))
+                if self.use_pointer:
+                    tokens.append(("class:pointer",
+                                   " {} ".format(SELECTED_POINTER)))
+                else:
+                    tokens.append(("", "   "))
+
                 tokens.append(("[SetCursorPosition]", ""))
             else:
                 tokens.append(("", "   "))

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -29,6 +29,7 @@ def select(message: Text,
            style: Optional[Style] = None,
            use_shortcuts: bool = False,
            use_indicator: bool = False,
+           use_pointer: bool = True,
            **kwargs: Any) -> Question:
     """Prompt the user to select one item from the list of choices.
 
@@ -57,6 +58,9 @@ def select(message: Text,
         use_shortcuts: Allow the user to select items from the list using
                        shortcuts. The shortcuts will be displayed in front of
                        the list items.
+
+        use_pointer: Flag to enable the pointer in front of the currently
+                     highlighted element.
     Returns:
         Question: Question instance, ready to be prompted (using `.ask()`).
     """
@@ -75,7 +79,8 @@ def select(message: Text,
 
     ic = InquirerControl(choices, default,
                          use_indicator=use_indicator,
-                         use_shortcuts=use_shortcuts)
+                         use_shortcuts=use_shortcuts,
+                         use_pointer=use_pointer)
 
     def get_prompt_tokens():
         # noinspection PyListCreation

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -90,7 +90,8 @@ def select(message: Text,
         if ic.is_answered:
             if isinstance(ic.get_pointed_at().title, list):
                 tokens.append(("class:answer",
-                               "".join([token[1] for token in ic.get_pointed_at().title])))
+                               "".join([token[1] for token in
+                                       ic.get_pointed_at().title])))
             else:
                 tokens.append(("class:answer", ' ' + ic.get_pointed_at().title))
         else:

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -88,7 +88,11 @@ def select(message: Text,
                   ("class:question", ' {} '.format(message))]
 
         if ic.is_answered:
-            tokens.append(("class:answer", ' ' + ic.get_pointed_at().title))
+            if isinstance(ic.get_pointed_at().title, list):
+                tokens.append(("class:answer",
+                               "".join([token[1] for token in ic.get_pointed_at().title])))
+            else:
+                tokens.append(("class:answer", ' ' + ic.get_pointed_at().title))
         else:
             if use_shortcuts:
                 tokens.append(("class:instruction", ' (Use shortcuts)'))

--- a/tests/prompts/test_checkbox.py
+++ b/tests/prompts/test_checkbox.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from questionary import Separator
+from questionary import Separator, Choice
 from tests.utils import feed_cli_with_input, KeyInputs
 
 
@@ -20,6 +20,21 @@ def test_select_first_choice():
     message = 'Foo message'
     kwargs = {
         'choices': ['foo', 'bar', 'bazz']
+    }
+    text = KeyInputs.SPACE + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input('checkbox', message, text, **kwargs)
+    assert result == ["foo"]
+
+
+def test_select_first_choice_with_token_title():
+    message = 'Foo message'
+    kwargs = {
+        'choices': [
+            Choice(title=[('class:text', 'foo')]),
+            Choice(title=[('class:text', 'bar')]),
+            Choice(title=[('class:text', 'bazz')])
+        ]
     }
     text = KeyInputs.SPACE + KeyInputs.ENTER + "\r"
 

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -39,7 +39,7 @@ def test_select_first_choice_with_token_title():
     text = KeyInputs.ENTER + "\r"
 
     result, cli = feed_cli_with_input('select', message, text, **kwargs)
-    assert result == ["foo"]
+    assert result == 'foo'
 
 
 def test_select_second_choice():

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from questionary import Separator
+from questionary import Separator, Choice
 from tests.utils import feed_cli_with_input, KeyInputs
 
 
@@ -25,6 +25,21 @@ def test_select_first_choice():
 
     result, cli = feed_cli_with_input('select', message, text, **kwargs)
     assert result == 'foo'
+
+
+def test_select_first_choice_with_token_title():
+    message = 'Foo message'
+    kwargs = {
+        'choices': [
+            Choice(title=[('class:text', 'foo')]),
+            Choice(title=[('class:text', 'bar')]),
+            Choice(title=[('class:text', 'bazz')])
+        ]
+    }
+    text = KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input('checkbox', message, text, **kwargs)
+    assert result == ["foo"]
 
 
 def test_select_second_choice():

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -38,7 +38,7 @@ def test_select_first_choice_with_token_title():
     }
     text = KeyInputs.ENTER + "\r"
 
-    result, cli = feed_cli_with_input('checkbox', message, text, **kwargs)
+    result, cli = feed_cli_with_input('select', message, text, **kwargs)
     assert result == ["foo"]
 
 


### PR DESCRIPTION
This PR adds a several new methods of styling the `select` and `checkbox` prompts
* Add flag to disable drawing of the pointer character
* Add `highlighted` token to style the choice being pointed to
  * This style will only be applied when `use_pointer` is `False`
* Add `text` token to style ordinary text
* Add `disabled` token to style disabled choices
* Disabled value is no longer displayed if it is a `bool`
* Choice titles can now be a `list` of token tuples to support custom styling
  * The answer displayed after the prompt is closed will use the `answer` token
  * This type of styling means that `selected` and `highlighted` tokens will have no effect

I originally thought that `use_indicator` would serve the same purpose as `use_pointer` in this PR, but for `select` it turns on the `checkbox` style checkbox symbol. I suggest removing this option from the `select` prompt as well, but I wanted to discuss before making that change.
https://github.com/tmbo/questionary/blob/da7a2f9687d09e1eb7abbfb5500ff028634b3c4b/questionary/prompts/select.py#L53-L55

This PR supersedes #12 and #13 