### PR TITLE
Remove all use of Type annotation to work around 3.5.2 bug

### DIFF
--- a/questionary/prompts/password.py
+++ b/questionary/prompts/password.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import Text, Type, Union, Callable, Optional, Any
+from typing import Text, Union, Callable, Optional, Any
 
 from prompt_toolkit.styles import Style
 from prompt_toolkit.validation import Validator
@@ -11,9 +11,7 @@ from questionary.prompts import text
 
 def password(message: Text,
              default: Text = "",
-             validate: Union[Type[Validator],
-                             Callable[[Text], bool],
-                             None] = None,  # noqa
+             validate: Any = None,
              qmark: Text = DEFAULT_QUESTION_PREFIX,
              style: Optional[Style] = None,
              **kwargs: Any) -> Question:

--- a/questionary/prompts/text.py
+++ b/questionary/prompts/text.py
@@ -5,7 +5,7 @@ from prompt_toolkit.shortcuts.prompt import (
     PromptSession)
 from prompt_toolkit.styles import merge_styles, Style
 from prompt_toolkit.validation import Validator
-from typing import Text, Type, Union, Callable, Optional, Any
+from typing import Text, Union, Callable, Optional, Any
 
 from questionary.constants import DEFAULT_STYLE, DEFAULT_QUESTION_PREFIX
 from questionary.prompts.common import build_validator
@@ -14,9 +14,7 @@ from questionary.question import Question
 
 def text(message: Text,
          default: Text = "",
-         validate: Union[Type[Validator],
-                         Callable[[Text], bool],
-                         None] = None,  # noqa
+         validate: Any = None,
          qmark: Text = DEFAULT_QUESTION_PREFIX,
          style: Optional[Style] = None,
          **kwargs: Any) -> Question:


### PR DESCRIPTION
It looks like #8 did not cover everything. This removes _all_ annotations that directly use the `Type` class to allow 3.5.2 to use questionary. Closes #15 