### PR TITLE
Conditional skips

### DIFF
--- a/questionary/form.py
+++ b/questionary/form.py
@@ -39,7 +39,7 @@ class Form:
         while not all(f.key in answers for f in self.form_fields):
             for field in self.form_fields:
                 if field.key in answers:
-                    def skip(): return True
+                    def skip(x): return True
                 else:
                     skip = self.skip_conditions.get(field.key, lambda x: False)
                 values = {f.question: answers[f.key] for f in self.form_fields

--- a/questionary/form.py
+++ b/questionary/form.py
@@ -39,7 +39,8 @@ class Form:
         while not all(f.key in answers for f in self.form_fields):
             for field in self.form_fields:
                 if field.key in answers:
-                    def skip(x): return True
+                    def skip(values):
+                        return True
                 else:
                     skip = self.skip_conditions.get(field.key, lambda x: False)
                 values = {f.question: answers[f.key] for f in self.form_fields

--- a/questionary/form.py
+++ b/questionary/form.py
@@ -39,7 +39,7 @@ class Form:
         while not all(f.key in answers for f in self.form_fields):
             for field in self.form_fields:
                 if field.key in answers:
-                    skip = lambda x: True
+                    def skip(): return True
                 else:
                     skip = self.skip_conditions.get(field.key, lambda x: False)
                 values = {f.question: answers[f.key] for f in self.form_fields

--- a/questionary/form.py
+++ b/questionary/form.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from typing import Callable
 
 from questionary.constants import DEFAULT_KBI_MESSAGE
 from questionary.question import Question
@@ -21,11 +22,20 @@ class Form:
 
     def __init__(self, *form_fields: FormField):
         self.form_fields = form_fields
+        self.skip_conditions = {}
+
+    def skip_if(self, **conditions: Callable):
+        for k, condition in conditions.items():
+            self.skip_conditions[k] = condition
+        return self
 
     def unsafe_ask(self, patch_stdout=False):
         answers = {}
         for f in self.form_fields:
-            answers[f.key] = f.question.unsafe_ask(patch_stdout)
+            if not self.skip_conditions.get(f.key, lambda x: False)(answers):
+                answers[f.key] = f.question.unsafe_ask(patch_stdout)
+            else:
+                answers[f.key] = f.question.default
         return answers
 
     def ask(self, patch_stdout=False, kbi_msg=DEFAULT_KBI_MESSAGE):

--- a/questionary/form.py
+++ b/questionary/form.py
@@ -39,10 +39,8 @@ class Form:
         while not all(f.key in answers for f in self.form_fields):
             for field in self.form_fields:
                 if field.key in answers:
-                    def skip(values):
-                        return True
-                else:
-                    skip = self.skip_conditions.get(field.key, lambda x: False)
+                    continue
+                skip = self.skip_conditions.get(field.key, lambda x: False)
                 values = {f.question: answers[f.key] for f in self.form_fields
                           if f.key in answers}
                 values.update(answers)  # question and keys as keys in values

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -152,9 +152,13 @@ def checkbox(message: Text,
         """Disallow inserting other text. """
         pass
 
+    if default is None:
+        return_default = tuple(getattr(c, 'value') for c in choices
+                               if getattr(c, 'checked', False))
+    else:
+        return_default = default
     return Question(Application(
         layout=layout,
         key_bindings=bindings,
         style=merged_style,
-        **kwargs
-    ))
+        **kwargs), default=return_default)

--- a/questionary/prompts/confirm.py
+++ b/questionary/prompts/confirm.py
@@ -91,4 +91,4 @@ def confirm(message: Text,
     return Question(PromptSession(get_prompt_tokens,
                                   key_bindings=bindings,
                                   style=merged_style,
-                                  **kwargs).app)
+                                  **kwargs).app, default=default)

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -155,5 +155,4 @@ def select(message: Text,
         layout=layout,
         key_bindings=bindings,
         style=merged_style,
-        **kwargs
-    ))
+        **kwargs), default=default)

--- a/questionary/prompts/text.py
+++ b/questionary/prompts/text.py
@@ -60,4 +60,4 @@ def text(message: Text,
                       **kwargs)
     p.default_buffer.reset(Document(default))
 
-    return Question(p.app)
+    return Question(p.app, default=default)

--- a/questionary/question.py
+++ b/questionary/question.py
@@ -68,7 +68,8 @@ class Question(FrozenOperationMixin):
         self.default = default
 
     def __hash__(self):
-        return hash(str(hash(self.application)) + str(self.default) + str(self.should_skip_question))
+        return hash(str(hash(self.application)) + str(self.default) +
+                    str(self.should_skip_question))
 
     async def ask_async(self,
                         patch_stdout: bool = False,

--- a/questionary/question.py
+++ b/questionary/question.py
@@ -4,10 +4,59 @@ import prompt_toolkit.patch_stdout
 
 from questionary import utils
 from questionary.constants import DEFAULT_KBI_MESSAGE
-from typing import Any
+from typing import Any, Union
+
+__all__ = ['Question']
 
 
-class Question:
+class FrozenOperationMixin:
+    def __eq__(self, other: object):
+        return FrozenOperation('eq', self, other)
+
+    def __ne__(self, other: object):
+        return FrozenOperation('ne', self, other)
+
+    def __gt__(self, other: object):
+        return FrozenOperation('gt', self, other)
+
+    def __lt__(self, other: object):
+        return FrozenOperation('lt', self, other)
+
+    def __and__(self, other: object):
+        return FrozenOperation('and', self, other)
+
+    def __or__(self, other: object):
+        return FrozenOperation('or', self, other)
+
+    def __le__(self, other: object):
+        return FrozenOperation('le', self, other)
+
+    def __ge__(self, other: object):
+        return FrozenOperation('ge', self, other)
+
+    def __xor__(self, other: object):
+        return FrozenOperation('xor', self, other)
+
+    def __add__(self, other: object):
+        return FrozenOperation('add', self, other)
+
+    def __sub__(self, other: object):
+        return FrozenOperation('sub', self, other)
+
+    def __mul__(self, other: object):
+        return FrozenOperation('mul', self, other)
+
+    def __divmod__(self, other: object):
+        return FrozenOperation('divmod', self, other)
+
+    def __abs__(self):
+        return FrozenOperation('abs', self)
+
+    def __truediv__(self, other: object):
+        return FrozenOperation('truediv', self, other)
+
+
+class Question(FrozenOperationMixin):
     """A question to be prompted.
 
     This is an internal class. Questions should be created using the
@@ -17,6 +66,9 @@ class Question:
         self.application = application
         self.should_skip_question = False
         self.default = default
+
+    def __hash__(self):
+        return hash(str(hash(self.application)) + str(self.default) + str(self.should_skip_question))
 
     async def ask_async(self,
                         patch_stdout: bool = False,
@@ -78,3 +130,32 @@ class Question:
             return await self.application.run_async().to_asyncio_future()
         else:
             return await self.application.run_async().to_asyncio_future()
+
+
+class FrozenOperation(FrozenOperationMixin):
+    def __init__(self, action: Union[str, None], a: Any, b: Any = None):
+        self.action = action
+        self.a = a
+        self.b = b
+
+    def __call__(self, values: dict) -> object:
+        if isinstance(self.a, FrozenOperation):
+            a = self.a(values)
+        elif isinstance(self.a, Question):
+            a = values[self.a]
+        else:
+            a = self.a
+
+        if self.action is None:
+            return a
+
+        if isinstance(self.b, FrozenOperation):
+            b = self.b(values)
+        elif isinstance(self.b, Question):
+            b = values[self.b]
+        else:
+            b = self.b
+
+        if b is None:
+            return getattr(a, '__' + self.action + '__')()
+        return getattr(a, '__' + self.action + '__')(b)

--- a/questionary/question.py
+++ b/questionary/question.py
@@ -13,10 +13,10 @@ class Question:
     This is an internal class. Questions should be created using the
     predefined questions (e.g. text or password)."""
 
-    def __init__(self, application: prompt_toolkit.Application):
+    def __init__(self, application: prompt_toolkit.Application, default=None):
         self.application = application
         self.should_skip_question = False
-        self.default = None
+        self.default = default
 
     async def ask_async(self,
                         patch_stdout: bool = False,

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -17,6 +17,8 @@ def example_form(inp):
                                       output=DummyOutput(),
                                       default='default'
                                       )).skip_if(q2=lambda x: not x['q1'])
+
+
 def test_form_creation():
     inp = create_pipe_input()
     text = "Y" + KeyInputs.ENTER + "\r"
@@ -46,6 +48,7 @@ def test_ask_should_catch_keyboard_exception():
     finally:
         inp.close()
 
+
 def test_select_skip_on_condition():
     inp = create_pipe_input()
     text = "N" + KeyInputs.ENTER + "\r"
@@ -71,11 +74,11 @@ def test_checkbox_default_on_condition():
                                         input=inp,
                                         output=DummyOutput()),
                  q2=questionary.checkbox("World?",
-                                       choices=["foo", "bar"],
-                                       input=inp,
-                                       output=DummyOutput(),
-                                       default='default'
-                                       )).skip_if(q2=lambda x: not x['q1'])
+                                         choices=["foo", "bar"],
+                                         input=inp,
+                                         output=DummyOutput(),
+                                         default='default'
+                                         )).skip_if(q2=lambda x: not x['q1'])
 
         result = f.unsafe_ask()
 

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,3 +1,4 @@
+import pytest
 from prompt_toolkit.input.defaults import create_pipe_input
 from prompt_toolkit.output import DummyOutput
 from pytest import fail
@@ -73,12 +74,12 @@ def test_checkbox_default_on_condition():
         f = form(q1=questionary.confirm("Hello?",
                                         input=inp,
                                         output=DummyOutput()),
-                 q2=questionary.checkbox("World?",
-                                         choices=["foo", "bar"],
-                                         input=inp,
-                                         output=DummyOutput(),
-                                         default='default'
-                                         )).skip_if(q2=lambda x: not x['q1'])
+                 q2=questionary.select("World?",
+                                       choices=["foo", "bar"],
+                                       input=inp,
+                                       output=DummyOutput(),
+                                       default='default'
+                                       )).skip_if(q2=lambda x: not x['q1'])
 
         result = f.unsafe_ask()
 
@@ -87,7 +88,7 @@ def test_checkbox_default_on_condition():
         inp.close()
 
 
-def test_checkbox_checked_default_on_condition():
+def test_form_checkbox_skip_using_function():
     inp = create_pipe_input()
     text = "N" + KeyInputs.ENTER + "\r"
 
@@ -108,5 +109,168 @@ def test_checkbox_checked_default_on_condition():
         result = f.unsafe_ask()
 
         assert result == {'q1': False, 'q2': ("foo",)}
+    finally:
+        inp.close()
+
+
+@pytest.mark.parametrize('comp,in1,out2', [('eq', False, ('bar',)),
+                                           ('ne', True, ('bar',)),
+                                           ])
+def test_form_checkbox_skip_using_equality_comparison(comp, in1, out2):
+    inp = create_pipe_input()
+    if in1:
+        text = "Y"
+    else:
+        text = "N"
+    text += KeyInputs.ENTER + "\r"
+
+    try:
+        inp.send_text(text)
+        q1 = questionary.confirm("Hello?",
+                                 input=inp,
+                                 output=DummyOutput())
+        q2 = questionary.checkbox("World?",
+                                  choices=[
+                                      "foo",
+                                      Choice("bar", checked=True)
+                                  ],
+                                  input=inp,
+                                  output=DummyOutput(),
+                                  )
+        f = form(q1=q1, q2=q2).skip_if(
+            q2=getattr(q1, '__{}__'.format(comp))(False))
+
+        result = f.unsafe_ask()
+
+        assert result['q1'] == in1 and tuple(result['q2']) == out2
+    finally:
+        inp.close()
+
+
+numeric_tests = [
+    (2, 'gt', 3, False),
+    (3, 'gt', 2, True),
+    (3, 'lt', 2, False),
+    (2, 'lt', 3, True),
+    (2, 'ge', 3, False),
+    (3, 'ge', 2, True),
+    (3, 'le', 2, False),
+    (2, 'le', 3, True),
+    (True, 'and', True, True),
+    (True, 'and', False, False),
+    (True, 'or', False, True),
+    (False, 'or', False, False),
+    (True, 'xor', False, True),
+    (True, 'xor', True, False),
+]
+
+
+@pytest.mark.parametrize('in1,comp,comp_to,pass_test', numeric_tests)
+def test_form_skip_using_numeric_comparison(in1, comp, comp_to, pass_test):
+    inp = create_pipe_input()
+    text = KeyInputs.ENTER + "\r"
+
+    try:
+        inp.send_text(text)
+        q1 = questionary.select("Hello?", [Choice('a', in1), 'other'],
+                                input=inp,
+                                output=DummyOutput())
+        q2 = questionary.select("World?", ['performed'],
+                                default='skipped',
+                                input=inp,
+                                output=DummyOutput(),
+                                )
+        comparator = getattr(q1, '__{}__'.format(comp))
+        if comp_to is None:
+            comparison = comparator()
+        else:
+            comparison = comparator(comp_to)
+        f = form(q1=q1, q2=q2).skip_if(q2=comparison)
+
+        result = f.unsafe_ask()
+
+        assert result['q1'] == in1
+        if pass_test:
+            assert result['q2'] == 'skipped'
+        else:
+            assert result['q2'] == 'performed'
+    finally:
+        inp.close()
+
+
+@pytest.mark.parametrize('in1,comp,in2,pass_test', numeric_tests)
+def test_form_skip_using_numeric_comparison_qs(in1, comp, in2, pass_test):
+    inp = create_pipe_input()
+    text = KeyInputs.ENTER + "\r" + KeyInputs.ENTER + "\r"
+
+    try:
+        inp.send_text(text)
+        q1 = questionary.select("q1", [Choice('a', in1), 'other'],
+                                input=inp,
+                                output=DummyOutput())
+        q2 = questionary.select("q2", [Choice('a', in2), 'other'],
+                                input=inp,
+                                output=DummyOutput())
+        q3 = questionary.select("q3", ['performed'],
+                                default='skipped',
+                                input=inp,
+                                output=DummyOutput(),
+                                )
+        comparator = getattr(q1, '__{}__'.format(comp))
+        comparison = comparator(q2)
+        f = form(q1=q1, q2=q2, q3=q3).skip_if(q3=comparison)
+
+        result = f.unsafe_ask()
+
+        assert result['q1'] == in1
+        assert result['q2'] == in2
+        if pass_test:
+            assert result['q3'] == 'skipped'
+        else:
+            assert result['q3'] == 'performed'
+    finally:
+        inp.close()
+
+
+arithmetic_tests = [
+    (1, 'add', 2),
+    (1, 'sub', 2),
+    (1, 'mul', 2),
+    (10, 'divmod', 5),
+    (-1, 'abs', None),
+    (9, 'truediv', 4)
+]
+
+
+@pytest.mark.parametrize('in1,calc,in2', arithmetic_tests)
+def test_form_skip_using_arithmetic(in1, calc, in2):
+    inp = create_pipe_input()
+    text = KeyInputs.ENTER + "\r"
+    func = getattr(in1, '__{}__'.format(calc))
+    if in2 is None:
+        result = func()
+    else:
+        result = func(in2)
+    try:
+        inp.send_text(text)
+        q1 = questionary.select("Hello?", [Choice('a', in1), 'other'],
+                                input=inp,
+                                output=DummyOutput())
+        q2 = questionary.select("World?", ['performed'],
+                                default='skipped',
+                                input=inp,
+                                output=DummyOutput(),
+                                )
+        calculator = getattr(q1, '__{}__'.format(calc))
+        if in2 is None:
+            calculation = calculator()
+        else:
+            calculation = calculator(in2)
+        f = form(q1=q1, q2=q2).skip_if(q2=calculation == result)
+
+        result = f.unsafe_ask()
+
+        assert result['q1'] == in1
+        assert result['q2'] == 'skipped'
     finally:
         inp.close()

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -3,7 +3,7 @@ from prompt_toolkit.output import DummyOutput
 from pytest import fail
 
 import questionary
-from questionary import form
+from questionary import form, Choice
 from tests.utils import KeyInputs
 
 
@@ -14,10 +14,9 @@ def example_form(inp):
                 q2=questionary.select("World?",
                                       choices=["foo", "bar"],
                                       input=inp,
-                                      output=DummyOutput()
-                                      ))
-
-
+                                      output=DummyOutput(),
+                                      default='default'
+                                      )).skip_if(q2=lambda x: not x['q1'])
 def test_form_creation():
     inp = create_pipe_input()
     text = "Y" + KeyInputs.ENTER + "\r"
@@ -44,5 +43,67 @@ def test_ask_should_catch_keyboard_exception():
         assert result == {}
     except KeyboardInterrupt:
         fail("Keyboard Interrupt should be caught by `ask()`")
+    finally:
+        inp.close()
+
+def test_select_skip_on_condition():
+    inp = create_pipe_input()
+    text = "N" + KeyInputs.ENTER + "\r"
+
+    try:
+        inp.send_text(text)
+        f = example_form(inp)
+
+        result = f.unsafe_ask()
+
+        assert result == {'q1': False, 'q2': 'default'}
+    finally:
+        inp.close()
+
+
+def test_checkbox_default_on_condition():
+    inp = create_pipe_input()
+    text = "N" + KeyInputs.ENTER + "\r"
+
+    try:
+        inp.send_text(text)
+        f = form(q1=questionary.confirm("Hello?",
+                                        input=inp,
+                                        output=DummyOutput()),
+                 q2=questionary.checkbox("World?",
+                                       choices=["foo", "bar"],
+                                       input=inp,
+                                       output=DummyOutput(),
+                                       default='default'
+                                       )).skip_if(q2=lambda x: not x['q1'])
+
+        result = f.unsafe_ask()
+
+        assert result == {'q1': False, 'q2': 'default'}
+    finally:
+        inp.close()
+
+
+def test_checkbox_checked_default_on_condition():
+    inp = create_pipe_input()
+    text = "N" + KeyInputs.ENTER + "\r"
+
+    try:
+        inp.send_text(text)
+        f = form(q1=questionary.confirm("Hello?",
+                                        input=inp,
+                                        output=DummyOutput()),
+                 q2=questionary.checkbox("World?",
+                                         choices=[
+                                             Choice("foo", checked=True),
+                                             "bar"
+                                         ],
+                                         input=inp,
+                                         output=DummyOutput(),
+                                         )).skip_if(q2=lambda x: not x['q1'])
+
+        result = f.unsafe_ask()
+
+        assert result == {'q1': False, 'q2': ("foo",)}
     finally:
         inp.close()


### PR DESCRIPTION
Summary of propsed changes:

Allow skipping of questions based on the state of the answers dictionary when asking from a `form`. The `default` of each question is used when it is skipped (`checkbox` uses checked options when `default` is not available. Tests included


        >>> f = form(q1=questionary.confirm("Hello?"),
                      q2=questionary.checkbox("World?",
                                         choices=[
                                             Choice("foo", checked=True),
                                             "bar"
                                         ],
                                         )).skip_if(q2=lambda x: not x['q1'])

        >>> result = f.ask()
        Hello? (Y/n )n
        >>> result['q1'] == False, and result['q2'] =  ("foo",)
        True

<s>However, this breaks python 3.5 since orderddicts are not used in kwargs. Either we fix that by doing some dependency tracking or we stop supporting 3.5.</s> (fixed)