### PR TITLE
Enhance documentation regarding advanced workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Optional Keys:
 * `'choices'` - List of choices (applies when `'type': 'select'`) or function returning a list of choices.
 * `'when'` - Function checking if this question should be shown or skipped (same functionality than `.skip_if()`).
 * `'validate'` - Function or Validator Class performing validation (will be performed in real time as users type).
+* `filter` - Receive the user input and return the filtered value to be used inside the program. 
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -220,38 +220,38 @@ Questionary allows creating quite complex workflows when combining all of the ab
 ``` python
 from questionary import Separator, prompt
 questions = [
-        {
-            'type': 'confirm',
-            'name': 'conditional_step',
-            'message': 'Would you like the next question?',
-            'default': True,
-        },
-        {
-            'type': 'text',
-            'name': 'next_question',
-            'message': 'Name this library?',
-            # Validate if the first question was answered with yes or no
-            'when': lambda x: x['conditional_step'],
-            # Only accept questionary as answer
-            'validate': lambda val: val == 'questionary'
-        },
-        {
-            'type': 'select',
-            'name': 'second_question',
-            'message': 'Select item',
-            'choices': [
-                'item1',
-                'item2',
-                Separator(),
-                'other',
-            ],
-        },
-        {
-            'type': 'text',
-            'name': 'second_question',
-            'message': 'Insert free text',
-            'when': lambda x: x['second_question'] == 'other'
-        },
+    {
+        'type': 'confirm',
+        'name': 'conditional_step',
+        'message': 'Would you like the next question?',
+        'default': True,
+    },
+    {
+        'type': 'text',
+        'name': 'next_question',
+        'message': 'Name this library?',
+        # Validate if the first question was answered with yes or no
+        'when': lambda x: x['conditional_step'],
+        # Only accept questionary as answer
+        'validate': lambda val: val == 'questionary'
+    },
+    {
+        'type': 'select',
+        'name': 'second_question',
+        'message': 'Select item',
+        'choices': [
+            'item1',
+            'item2',
+            Separator(),
+            'other',
+        ],
+    },
+    {
+        'type': 'text',
+        'name': 'second_question',
+        'message': 'Insert free text',
+        'when': lambda x: x['second_question'] == 'other'
+    },
 ]
 prompt(questions)
 ```
@@ -259,7 +259,7 @@ prompt(questions)
 The above workflow will show to the user as follows:
 1. Yes/No question `Would you like the next question?`.
 2. `Name this library?` - only shown when the first question is answered with yes
-3. Itemselection
+3. A question to select an item from a list.
 4. Free text inpt if `'other'` is selected in step 3.
 
 Depending on the route the user took, the result will look as follows:

--- a/README.md
+++ b/README.md
@@ -196,6 +196,87 @@ answers = prompt(questions)
 ```
 
 The returned `answers` will be a dict containing the responses, e.g. `{"phone": "0123123", "continue": False, ""}`. The questions will be prompted one after another and `prompt` will return once all of them are answered.
+
+Each configuration dictionary needs to contain the following keys:
+
+* `'type'` - The type of the question.
+* `'name'` - The name of the question (will be used as key in the `answers` dictionary)
+* `'message'` - Message that will be shown to the user
+
+Optional Keys:
+
+* `'qmark'` - Question mark to use - defaults to `?`.
+* `'default'` - Preselected value.
+* `'choices'` - List of choices (applies when `'type': 'select'`).
+* `'when'` - Function checking if this question should be shown or skipped (same functionality than `.skip_if()`).
+* `'validate'` - Function or Validator Class performing validation (will be performed in real time as users type).
+
+</details>
+
+<details><summary>Advanced workflow examples</summary>
+Questionary allows creating quite complex workflows when combining all of the above concepts.
+
+``` python
+from questionary import Separator, prompt
+questions = [
+        {
+            'type': 'confirm',
+            'name': 'conditional_step',
+            'message': 'Would you like the next question?',
+            'default': True,
+        },
+       {
+            'type': 'text',
+            'name': 'next_question',
+            'message': 'Name this library?',
+            # Validate if the first question was answered with yes or no
+            'when': lambda x: x['conditional_step'],
+            # Only accept questionary as answer
+            'validate': lambda val: val == 'questionary'
+        },
+       {
+            'type': 'select',
+            'name': 'second_question',
+            'message': 'Select item',
+            'choices': [
+                'item1',
+                'item2',
+                Separator(),
+                'other',
+            ],
+        },
+        {
+            'type': 'text',
+            'name': 'second_question',
+            'message': 'Insert free text',
+            'when': lambda x: x['second_question'] == 'other'
+        },
+]
+prompt(questions)
+```
+
+The above workflow will show to the user as follows:
+1. Yes/No question `Would you like the next question?`.
+2. `Name this library?` - only shown when the first question is answered with yes
+3. Itemselection
+4. Free text inpt if `'other'` is selected in step 3.
+
+Depending on the route the user took, the result will look as follows:
+
+``` python
+{ 
+    'conditional_step': False,
+    'second_question': 'Testinput'   # Free form text
+}
+```
+``` python
+{ 
+    'conditional_step': True,
+    'next_question': 'questionary',
+    'second_question': 'Testinput'   # Free form text
+}
+```
+
 </details>
 
 <details><summary>Styling your prompts with your favorite colors</summary>

--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ Depending on the route the user took, the result will look as follows:
 }
 ```
 
+You can test this workflow yourself by running the [advanced_workflow.py example](https://github.com/tmbo/questionary/blob/master/examples/advanced_workflow.py).
+
 </details>
 
 <details><summary>Styling your prompts with your favorite colors</summary>

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ questions = [
             'message': 'Would you like the next question?',
             'default': True,
         },
-       {
+        {
             'type': 'text',
             'name': 'next_question',
             'message': 'Name this library?',
@@ -234,7 +234,7 @@ questions = [
             # Only accept questionary as answer
             'validate': lambda val: val == 'questionary'
         },
-       {
+        {
             'type': 'select',
             'name': 'second_question',
             'message': 'Select item',

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Optional Keys:
 
 * `'qmark'` - Question mark to use - defaults to `?`.
 * `'default'` - Preselected value.
-* `'choices'` - List of choices (applies when `'type': 'select'`).
+* `'choices'` - List of choices (applies when `'type': 'select'`) or function returning a list of choices.
 * `'when'` - Function checking if this question should be shown or skipped (same functionality than `.skip_if()`).
 * `'validate'` - Function or Validator Class performing validation (will be performed in real time as users type).
 

--- a/examples/advanced_workflow.py
+++ b/examples/advanced_workflow.py
@@ -31,6 +31,7 @@ def ask_dictstyle(**kwargs):
             },
             {
                 'type': 'text',
+                # intentionally overwrites result from previous question
                 'name': 'second_question',
                 'message': 'Insert free text',
                 'when': lambda x: x['second_question'] == 'other',

--- a/examples/advanced_workflow.py
+++ b/examples/advanced_workflow.py
@@ -1,0 +1,44 @@
+from pprint import pprint
+from questionary import Separator, prompt
+
+def ask_dictstyle(**kwargs):
+    questions = [
+            {
+                'type': 'confirm',
+                'name': 'conditional_step',
+                'message': 'Would you like the next question?',
+                'default': True,
+            },
+        {
+                'type': 'text',
+                'name': 'next_question',
+                'message': 'Name this library?',
+                # Validate if the first question was answered with yes or no
+                'when': lambda x: x['conditional_step'],
+                # Only accept questionary as answer
+                'validate': lambda val: val == 'questionary',
+            },
+        {
+                'type': 'select',
+                'name': 'second_question',
+                'message': 'Select item',
+                'choices': [
+                    'item1',
+                    'item2',
+                    Separator(),
+                    'other',
+                ],
+            },
+            {
+                'type': 'text',
+                'name': 'second_question',
+                'message': 'Insert free text',
+                'when': lambda x: x['second_question'] == 'other',
+            },
+    ]
+    return prompt(questions)
+
+
+
+if __name__ == "__main__":
+    pprint(ask_dictstyle())

--- a/examples/advanced_workflow.py
+++ b/examples/advanced_workflow.py
@@ -23,7 +23,7 @@ def ask_dictstyle(**kwargs):
             "type": "select",
             "name": "second_question",
             "message": "Select item",
-            "choices": ["item1", "item2", Separator(), "other",],
+            "choices": ["item1", "item2", Separator(), "other"],
         },
         {
             "type": "text",

--- a/examples/advanced_workflow.py
+++ b/examples/advanced_workflow.py
@@ -5,37 +5,32 @@ from questionary import Separator, prompt
 def ask_dictstyle(**kwargs):
     questions = [
         {
-            'type': 'confirm',
-            'name': 'conditional_step',
-            'message': 'Would you like the next question?',
-            'default': True,
+            "type": "confirm",
+            "name": "conditional_step",
+            "message": "Would you like the next question?",
+            "default": True,
         },
         {
-            'type': 'text',
-            'name': 'next_question',
-            'message': 'Name this library?',
+            "type": "text",
+            "name": "next_question",
+            "message": "Name this library?",
             # Validate if the first question was answered with yes or no
-            'when': lambda x: x['conditional_step'],
+            "when": lambda x: x["conditional_step"],
             # Only accept questionary as answer
-            'validate': lambda val: val == 'questionary',
+            "validate": lambda val: val == "questionary",
         },
         {
-            'type': 'select',
-            'name': 'second_question',
-            'message': 'Select item',
-            'choices': [
-                    'item1',
-                    'item2',
-                    Separator(),
-                    'other',
-            ],
+            "type": "select",
+            "name": "second_question",
+            "message": "Select item",
+            "choices": ["item1", "item2", Separator(), "other",],
         },
         {
-            'type': 'text',
+            "type": "text",
             # intentionally overwrites result from previous question
-            'name': 'second_question',
-            'message': 'Insert free text',
-            'when': lambda x: x['second_question'] == 'other',
+            "name": "second_question",
+            "message": "Insert free text",
+            "when": lambda x: x["second_question"] == "other",
         },
     ]
     return prompt(questions)

--- a/examples/advanced_workflow.py
+++ b/examples/advanced_workflow.py
@@ -1,44 +1,44 @@
 from pprint import pprint
 from questionary import Separator, prompt
 
+
 def ask_dictstyle(**kwargs):
     questions = [
-            {
-                'type': 'confirm',
-                'name': 'conditional_step',
-                'message': 'Would you like the next question?',
-                'default': True,
-            },
         {
-                'type': 'text',
-                'name': 'next_question',
-                'message': 'Name this library?',
-                # Validate if the first question was answered with yes or no
-                'when': lambda x: x['conditional_step'],
-                # Only accept questionary as answer
-                'validate': lambda val: val == 'questionary',
-            },
+            'type': 'confirm',
+            'name': 'conditional_step',
+            'message': 'Would you like the next question?',
+            'default': True,
+        },
         {
-                'type': 'select',
-                'name': 'second_question',
-                'message': 'Select item',
-                'choices': [
+            'type': 'text',
+            'name': 'next_question',
+            'message': 'Name this library?',
+            # Validate if the first question was answered with yes or no
+            'when': lambda x: x['conditional_step'],
+            # Only accept questionary as answer
+            'validate': lambda val: val == 'questionary',
+        },
+        {
+            'type': 'select',
+            'name': 'second_question',
+            'message': 'Select item',
+            'choices': [
                     'item1',
                     'item2',
                     Separator(),
                     'other',
-                ],
-            },
-            {
-                'type': 'text',
-                # intentionally overwrites result from previous question
-                'name': 'second_question',
-                'message': 'Insert free text',
-                'when': lambda x: x['second_question'] == 'other',
-            },
+            ],
+        },
+        {
+            'type': 'text',
+            # intentionally overwrites result from previous question
+            'name': 'second_question',
+            'message': 'Insert free text',
+            'when': lambda x: x['second_question'] == 'other',
+        },
     ]
     return prompt(questions)
-
 
 
 if __name__ == "__main__":

--- a/questionary/prompt.py
+++ b/questionary/prompt.py
@@ -67,13 +67,13 @@ def prompt(
                         )
                 else:
                     raise ValueError(
-                        "'when' needs to be function that " "accepts a dict argument"
+                        "'when' needs to be function that accepts a dict argument"
                     )
             if _filter:
                 # at least a little sanity check!
                 if not callable(_filter):
                     raise ValueError(
-                        "'filter' needs to be function that " "accepts an argument"
+                        "'filter' needs to be function that accepts an argument"
                     )
 
             if callable(question_config.get("default")):


### PR DESCRIPTION
As said in #34, the documentation lacks examples for advanced workflows, so this aims to provide some (for sure not complete ...).

I've also added a working example workflow - but only as dictionary configuration (`ask_dictstyle()`) for now.
Mainly because I'm not certain if this workflow style would also work for the pystyle calling possibilities without adding an if-statement and calling the questions one by one (as done in `examples/readme.py`).

The disadvantage this "one by one" calling (as done in `examples/readme.py` ) is that a user cannot easily interrupt the process with ctrl+c - but has to do that for every following question.

With the dict-style (and calling prompt only once), one interrupt will return the user immediately, no matter how many questions would still be left.

