### PR TITLE
Update dev requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 - pip install prompt_toolkit==$PROMTTOOLKITVER
 - pip list
 script:
-- pytest --codestyle -m codestyle
+- pytest --pycodestyle -m codestyle
 - travis_wait pytest tests --cov questionary -v
 after_success:
 - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 python:
 - "3.6"
 - "3.7"
+- "3.8"
 env:
 - PROMTTOOLKITVER=3.*
 - PROMTTOOLKITVER=2.*
@@ -16,8 +17,8 @@ install:
 - pip install prompt_toolkit==$PROMTTOOLKITVER
 - pip list
 script:
-- py.test --codestyle -m codestyle
-- travis_wait py.test tests --cov questionary -v
+- pytest --codestyle -m codestyle
+- travis_wait pytest tests --cov questionary -v
 after_success:
 - coveralls
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ install:
 - pip install prompt_toolkit==$PROMTTOOLKITVER
 - pip list
 script:
-- pytest --pycodestyle -m codestyle
-- travis_wait pytest tests --cov questionary -v
+- travis_wait pytest --pycodestyle --cov questionary -v
 after_success:
 - coveralls
 jobs:

--- a/README.md
+++ b/README.md
@@ -252,7 +252,8 @@ will be the text concatenated (`'plain text bold text'` in the above example).
     branch off of it).
 3.  Write a test which shows that the bug was fixed or that the feature
     works as expected.
-4.  Send a pull request and bug the maintainer until it gets merged and
+4.  Ensure your code passes running `black questionary`.
+5.  Send a pull request and bug the maintainer until it gets merged and
     published. 🙂
 
 ## Contributors

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-pytest==4.0.1
-pytest-pycodestyle==1.3.1
-pytest-cov==2.6.0
-coveralls==1.3.0
+pytest==5.3.5
+pytest-pycodestyle==2.0.0
+pytest-cov==2.8.1
+coveralls==1.10.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,4 @@ pytest==5.3.5
 pytest-pycodestyle==2.0.0
 pytest-cov==2.8.1
 coveralls==1.10.0
+black==19.10b0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # pytest pycodestyle configuration
-[tool:pytest]
-codestyle_max_line_length = 88
-codestyle_ignore =
+[pycodestyle]
+max-line-length = 88
+ignore  =
     *.py W504
     *.py E251
     *.py W503

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,19 +1,7 @@
 # pytest pycodestyle configuration
 [pycodestyle]
 max-line-length = 88
-ignore  =
-    *.py W504
-    *.py E251
-    *.py W503
-    *.py E121
-    *.py E126
-    *.py E211
-    *.py E225
-    *.py E501
-    *.py E203
-    *.py E402
-    *.py F401
-    *.py F811
+ignore = W504,E251,W503,E121,E126,E211,E225,E501,E203,E402,F401,F811
 [metadata]
 description-file = README.md
 license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 tests_requires = [
-    "pytest~=4.0",
-    "pytest-pycodestyle~=1.3",
-    "pytest-cov~=2.6",
-    "coveralls~=1.3",
+    "pytest",
+    "pytest-pycodestyle",
+    "pytest-cov",
+    "coveralls",
 ]
 
 install_requires = ["prompt_toolkit>=2.0,<4.0"]


### PR DESCRIPTION
I think dev requirements need an urgent update as they are quite outdated.

The versions pinned in requirements_dev.txt do not work on more recent versions of python (3.8).

Also - you seem to run black (there is a configuration, and commits mentioning "black" not long ago - so it would be good to mention that to Contributors too - ensuring you get the pull-request already "blackified".

In addition to this, i'd propose to set something like [dependabot](https://dependabot.com/) up for this repository, to keep dependencies uptodate.
This however requires the repo owner - as it'll need to be added to the repository.

It can be configured to only update once every week or so, keeping "random noise" to a minimum.

## Quick changelog:
* run tests additionally with python 3.8
* update dev-dependencies
* add mention of black to requirements_dev.txt and readme.md