### PR TITLE
Prefix filter search

### DIFF
--- a/questionary/constants.py
+++ b/questionary/constants.py
@@ -35,6 +35,7 @@ DEFAULT_STYLE = Style(
         ("qmark", "fg:#5f819d"),  # token in front of the question
         ("question", "bold"),  # question text
         ("answer", "fg:#FF9D00 bold"),  # submitted answer text behind the question
+        ("search", "noinherit fg:#FF6600 bold"),  # submitted answer text behind the question
         ("pointer", ""),  # pointer used in select and checkbox prompts
         ("selected", ""),  # style for a selected item of a checkbox
         ("separator", ""),  # separator in lists

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -155,6 +155,7 @@ class InquirerControl(FormattedTextControl):
         self.is_answered = False
         self.choices = []
         self.selected_options = []
+        self.prefix_search_filter = ""
 
         self._init_choices(choices)
         self._assign_shortcut_keys()

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -159,10 +159,11 @@ def select(
 
         if use_prefix_filter_search:
             def search_filter(event):
-                pass
+                ic.add_search_character(event.key_sequence[0].key)
 
             for character in string.printable:
                 bindings.add(character, eager=True)(search_filter)
+            bindings.add(Keys.Backspace, eager=True)(search_filter)
         else:
             # Enable vi-like navigation
             bindings.add("j", eager=True)(move_cursor_down)

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -144,3 +144,21 @@ def test_select_empty_choices():
 
     with pytest.raises(ValueError):
         feed_cli_with_input("select", message, text, **kwargs)
+
+
+def test_filter_prefix_one_letter():
+    message = "Foo message"
+    kwargs = {"choices": ["abc", "def", "ghi", "jkl"]}
+    text = "g" + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("select", message, text, **kwargs)
+    assert result == "ghi"
+
+
+def test_filter_prefix_multiple_letters():
+    message = "Foo message"
+    kwargs = {"choices": ["abc", "def", "ghi", "jkl", "jag", "jja"]}
+    text = "j" + "j" + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("select", message, text, **kwargs)
+    assert result == "jja"

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -151,7 +151,9 @@ def test_filter_prefix_one_letter():
     kwargs = {"choices": ["abc", "def", "ghi", "jkl"]}
     text = "g" + KeyInputs.ENTER + "\r"
 
-    result, cli = feed_cli_with_input("select", message, text, **kwargs)
+    result, cli = feed_cli_with_input(
+        "select", message, text, use_prefix_filter_search=True, **kwargs
+    )
     assert result == "ghi"
 
 
@@ -160,5 +162,42 @@ def test_filter_prefix_multiple_letters():
     kwargs = {"choices": ["abc", "def", "ghi", "jkl", "jag", "jja"]}
     text = "j" + "j" + KeyInputs.ENTER + "\r"
 
-    result, cli = feed_cli_with_input("select", message, text, **kwargs)
+    result, cli = feed_cli_with_input(
+        "select", message, text, use_prefix_filter_search=True, **kwargs
+    )
     assert result == "jja"
+
+
+def test_select_filter_handle_backspace():
+    message = "Foo message"
+    kwargs = {"choices": ["abc", "def", "ghi", "jkl", "jag", "jja"]}
+    text = "j" + "j" + KeyInputs.BACK + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input(
+        "select", message, text, use_prefix_filter_search=True, **kwargs
+    )
+    assert result == "jkl"
+
+    message = "Foo message"
+    kwargs = {"choices": ["abc", "def", "ghi", "jkl", "jag", "jja"]}
+    text = (
+        "j" + "j" +
+        KeyInputs.BACK + KeyInputs.BACK + KeyInputs.BACK + KeyInputs.BACK +
+        KeyInputs.ENTER + "\r"
+    )
+
+    result, cli = feed_cli_with_input(
+        "select", message, text, use_prefix_filter_search=True, **kwargs
+    )
+    assert result == "abc"
+
+
+def test_select_goes_back_to_top_after_filtering():
+    message = "Foo message"
+    kwargs = {"choices": ["abc", "def", "ghi", "jkl", "jag", "jja"]}
+    text = KeyInputs.DOWN + KeyInputs.DOWN + "j" + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input(
+        "select", message, text, use_prefix_filter_search=True, **kwargs
+    )
+    assert result == "jkl"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,7 +27,7 @@ def feed_cli_with_input(_type, message, texts, sleep_time=1, **kwargs):
     Create a Prompt, feed it with the given user input and return the CLI
     object.
 
-    You an provide multiple texts, the feeder will async sleep for `sleep_time`
+    You can provide multiple texts, the feeder will async sleep for `sleep_time`
 
     This returns a (result, Application) tuple.
     """


### PR DESCRIPTION
Fixes #33 

Here is a first implementation

- it is optional, off by default to not change current behavior
- when active, vi-like navigation (`j` and `k`) is disabled
- when active, typing any character will add this character to the search filter
- when active, backspace is supported to remove the last input character. If the filter is empty, no filter is applied
- when the filter changes, since the displayed elements change, the cursor goes back to the top, position 0

A possible alternative would be to activate the search only on a certain key, let's say `/` or `Ctrl+F`. Doing so, the `select` control could "change mode" like vi would, and any key type from then on, would go to the filter. `Esc` could clear the filter. `Enter` could either select the current entry or validate the filter and go back to navigation mode. Like that, we would not have to disable vi-like navigation.

WDYT?


Note: I'd like some tests on what is displayed. I tried with a `prompt-toolkit` `Output` but the string rendered is a bit messy and validation would be awkward. I think it might be worth adding tests directly to the `InquirerControl` and the tokens it returns or the `prompt-toolkit` `Layout` it calls.
I might have a look into it if/when we agree on the implementation for this feature