### PR TITLE
Added validation for checkboxes

### DIFF
--- a/examples/checkbox_toppings.py
+++ b/examples/checkbox_toppings.py
@@ -4,7 +4,10 @@ import questionary
 if __name__ == "__main__":
     toppings = (
         questionary.checkbox(
-            "Select toppings", choices=["foo", "bar", "bazz"], style=custom_style_dope
+            "Select toppings",
+            choices=["foo", "bar", "bazz"],
+            validate=lambda a: (len(a) != 0, "You must select at least one topping"),
+            style=custom_style_dope,
         ).ask()
         or []
     )

--- a/tests/prompts/test_checkbox.py
+++ b/tests/prompts/test_checkbox.py
@@ -182,3 +182,33 @@ def test_list_ctr_c():
 
     with pytest.raises(KeyboardInterrupt):
         feed_cli_with_input("checkbox", message, text, **kwargs)
+
+
+def test_validate_default_message():
+    message = "Foo message"
+    kwargs = {"choices": ["foo", "bar", "bazz"], "validate": lambda a: len(a) != 0}
+    text = KeyInputs.ENTER + "i" + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("checkbox", message, text, **kwargs)
+    assert result == ["foo", "bar", "bazz"]
+
+
+def test_validate_with_message():
+    message = "Foo message"
+    kwargs = {
+        "choices": ["foo", "bar", "bazz"],
+        "validate": lambda a: (len(a) != 0, "Error Message"),
+    }
+    text = KeyInputs.ENTER + "i" + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("checkbox", message, text, **kwargs)
+    assert result == ["foo", "bar", "bazz"]
+
+
+def test_validate_not_callable():
+    message = "Foo message"
+    kwargs = {"choices": ["foo", "bar", "bazz"], "validate": "invalid"}
+    text = KeyInputs.ENTER + "i" + KeyInputs.ENTER + "\r"
+
+    with pytest.raises(ValueError):
+        feed_cli_with_input("checkbox", message, text, **kwargs)


### PR DESCRIPTION
I've added validation to the checkbox prompt.

`prompt-toolkit` does not provide native validation for `FormattedTextControl` (the parent class of `InquirerControl`). Therefore while `text` prompts support validators in the form of a `Validator` subclass, this only accepts a `callable` returning a boolean and optional error message. This restriction means asynchronous validators supported by `prompt-toolkit` cannot be used for the checkbox.

If/when `prompt-toolkit` provides native validation for a `FormattedTextControl`, this validation logic for the checkbox can be replaced.

Even with its limitations, I think this covers the fast majority of use cases for checkbox validation - it should be useful to some people.