### PR TITLE
Add py.typed marker file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE NOTICE README.md requirements.txt
 include pyproject.toml
+include questionary/py.typed
 recursive-include docs *.gif
 recursive-include docs *.png
 recursive-include examples *.py

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "Topic :: Software Development :: Libraries",
     ],
     packages=find_packages(exclude=["tests", "tests.*", "examples"]),
+    package_data={"": ["py.typed"]},
     version=__version__,
     install_requires=install_requires,
     tests_require=tests_requires,

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "Topic :: Software Development :: Libraries",
     ],
     packages=find_packages(exclude=["tests", "tests.*", "examples"]),
-    package_data={"": ["py.typed"]},
+    package_data={"questionary": ["py.typed"]},
     version=__version__,
     install_requires=install_requires,
     tests_require=tests_requires,


### PR DESCRIPTION
Questionary has type annotations but in the
absence of `py.typed` the annotations might be
ignored or the types incorrectly inferred
by type checkers.