### PR TITLE
Document multiline input for devs and users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
   - stage: codestyle
     python: 3.7
     install: pip install -r requirements_dev.txt
-    script: black --check .
+    script: black --check --diff .
     after_success: skip
   - stage: deploy
     python: 3.6

--- a/questionary/constants.py
+++ b/questionary/constants.py
@@ -14,6 +14,9 @@ YES_OR_NO = "(Y/n)"
 # Instruction text for a confirmation question (no is default)
 NO_OR_YES = "(y/N)"
 
+# Instruction for multiline input
+INSTRUCTION_MULTILINE = "(Finish with 'Alt+Enter' or 'Esc, Enter')"
+
 # Selection token used to indicate the selection cursor in a list
 SELECTED_POINTER = "»"
 

--- a/questionary/prompts/text.py
+++ b/questionary/prompts/text.py
@@ -7,7 +7,11 @@ from prompt_toolkit.shortcuts.prompt import PromptSession
 from prompt_toolkit.styles import Style, merge_styles
 from prompt_toolkit.lexers import SimpleLexer
 
-from questionary.constants import DEFAULT_QUESTION_PREFIX, DEFAULT_STYLE
+from questionary.constants import (
+    DEFAULT_QUESTION_PREFIX,
+    DEFAULT_STYLE,
+    INSTRUCTION_MULTILINE,
+)
 from questionary.prompts.common import build_validator
 from questionary.question import Question
 
@@ -18,6 +22,8 @@ def text(
     validate: Any = None,
     qmark: Text = DEFAULT_QUESTION_PREFIX,
     style: Optional[Style] = None,
+    multiline: bool = False,
+    instruction: Optional[Text] = None,
     **kwargs: Any
 ) -> Question:
     """Prompt the user to enter a free text message.
@@ -44,6 +50,11 @@ def text(
         style: A custom color and style for the question parts. You can
                configure colors as well as font types for different elements.
 
+        multiline: If `True`, multiline input will be enabled.
+
+        instruction: Write instructions for the user if needed. If `None`
+                     and `multiline=True`, some instructions will appear.
+
     Returns:
         Question: Question instance, ready to be prompted (using `.ask()`).
     """
@@ -52,14 +63,21 @@ def text(
 
     validator = build_validator(validate)
 
+    if instruction is None and multiline:
+        instruction = INSTRUCTION_MULTILINE
+
     def get_prompt_tokens() -> List[Tuple[Text, Text]]:
-        return [("class:qmark", qmark), ("class:question", " {} ".format(message))]
+        result = [("class:qmark", qmark), ("class:question", " {} ".format(message))]
+        if instruction:
+            result.append(("class:instruction", " {} ".format(instruction)))
+        return result
 
     p = PromptSession(
         get_prompt_tokens,
         style=merged_style,
         validator=validator,
         lexer=SimpleLexer("class:answer"),
+        multiline=multiline,
         **kwargs,
     )
     p.default_buffer.reset(Document(default))

--- a/tests/test_question.py
+++ b/tests/test_question.py
@@ -62,3 +62,14 @@ def test_async_ask_question():
         assert response == "World"
     finally:
         inp.close()
+
+
+def test_multiline_text():
+    inp = create_pipe_input()
+    try:
+        inp.send_text(f"Hello{KeyInputs.ENTER}world{KeyInputs.ESCAPE}{KeyInputs.ENTER}")
+        question = text("Hello?", input=inp, output=DummyOutput(), multiline=True)
+        response = question.ask()
+        assert response == "Hello\nworld"
+    finally:
+        inp.close()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,7 +14,7 @@ class KeyInputs(object):
     UP = "\x1b[A"
     LEFT = "\x1b[D"
     RIGHT = "\x1b[C"
-    ENTER = "\x0a"
+    ENTER = "\r"
     ESCAPE = "\x1b"
     CONTROLC = "\x03"
     BACK = "\x7f"


### PR DESCRIPTION
For devs, this feature, that was already working, is now documented.

For users, a default instruction text appears when using multiline mode.

Fix #54.