### PR TITLE
Allow passing in a custom lexer

### DIFF
--- a/questionary/prompts/text.py
+++ b/questionary/prompts/text.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Text, List, Tuple
 from prompt_toolkit.document import Document
 from prompt_toolkit.shortcuts.prompt import PromptSession
 from prompt_toolkit.styles import Style, merge_styles
-from prompt_toolkit.lexers import SimpleLexer
+from prompt_toolkit.lexers import Lexer, SimpleLexer
 
 from questionary.constants import (
     DEFAULT_QUESTION_PREFIX,
@@ -24,6 +24,7 @@ def text(
     style: Optional[Style] = None,
     multiline: bool = False,
     instruction: Optional[Text] = None,
+    lexer: Optional[Lexer] = None,
     **kwargs: Any,
 ) -> Question:
     """Prompt the user to enter a free text message.
@@ -55,12 +56,15 @@ def text(
         instruction: Write instructions for the user if needed. If `None`
                      and `multiline=True`, some instructions will appear.
 
+        lexer: Supply a valid lexer to style the answer. Leave empty to
+               use a simple one by default.
+
     Returns:
         Question: Question instance, ready to be prompted (using `.ask()`).
     """
 
     merged_style = merge_styles([DEFAULT_STYLE, style])
-
+    lexer = lexer or SimpleLexer("class:answer")
     validator = build_validator(validate)
 
     if instruction is None and multiline:
@@ -76,7 +80,7 @@ def text(
         get_prompt_tokens,
         style=merged_style,
         validator=validator,
-        lexer=SimpleLexer("class:answer"),
+        lexer=lexer,
         multiline=multiline,
         **kwargs,
     )


### PR DESCRIPTION
I want to use pygments lexers when asking i.e. for YAML or JSON input.

If doing it right now, I get this error:

```
Traceback (most recent call last):
  File "/var/home/yajo/prodevel/copier/.venv/bin/copier", line 5, in <module>
    CopierApp.run()
  File "/var/home/yajo/prodevel/copier/.venv/lib/python3.8/site-packages/plumbum/cli/application.py", line 577, in run
    inst, retcode = subapp.run(argv, exit=False)
  File "/var/home/yajo/prodevel/copier/.venv/lib/python3.8/site-packages/plumbum/cli/application.py", line 572, in run
    retcode = inst.main(*tailargs)
  File "/var/home/yajo/prodevel/copier/copier/cli.py", line 38, in _wrapper
    return method(*args, **kwargs)
  File "/var/home/yajo/prodevel/copier/copier/cli.py", line 262, in main
    self.parent._copy(
  File "/var/home/yajo/prodevel/copier/copier/cli.py", line 173, in _copy
    return copy(
  File "/var/home/yajo/prodevel/copier/copier/main.py", line 135, in copy
    conf = make_config(**locals())
  File "/var/home/yajo/prodevel/copier/copier/config/factory.py", line 141, in make_config
    init_args["data_from_asking_user"] = query_user_data(
  File "/var/home/yajo/prodevel/copier/copier/config/user_data.py", line 497, in query_user_data
    return questionary.get_answers()
  File "/var/home/yajo/prodevel/copier/copier/config/user_data.py", line 360, in get_answers
    self.answers_user = prompt(
  File "/var/home/yajo/prodevel/copier/.venv/lib/python3.8/site-packages/questionary/prompt.py", line 95, in prompt
    question = create_question_func(**_kwargs)
  File "/var/home/yajo/prodevel/copier/.venv/lib/python3.8/site-packages/questionary/prompts/text.py", line 75, in text
    p = PromptSession(
TypeError: type object got multiple values for keyword argument 'lexer'
```

This should fix it.