### PR TITLE
Less restrictive python 3 dependency

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         promttoolkit: [3.*, 2.*]
         exclude:
           # tests on windows with prompt-toolkit 2.* do not complete

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ readme = "README.md"
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.6,<3.9"
+python = "^3.6"
 prompt_toolkit = ">=2.0,<4.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Using this new version specifier is equivalent to `>=3.6,<4.0.0`, which allows other projects using this same specifier work with yours.

I have this in my project, and when trying to add the master commit from questionary, poetry fails (correctly) with:

```
  SolverProblemError

  The current project's Python requirement (>=3.6.1,<4.0.0) is not compatible with some of the required packages Python requirement:
    - questionary requires Python >=3.6,<3.9, so it will not be satisfied for Python >=3.9,<4.0.0

  Because copier depends on questionary (1.6.0 git rev text-custom-lexer) which requires Python >=3.6,<3.9, version solving failed.

  at ~/.local/pipx/venvs/poetry/lib64/python3.8/site-packages/poetry/puzzle/solver.py:241 in _solve
      237│             packages = result.packages
      238│         except OverrideNeeded as e:
      239│             return self.solve_in_compatibility_mode(e.overrides, use_latest=use_latest)
      240│         except SolveFailure as e:
    → 241│             raise SolverProblemError(e)
      242│
      243│         results = dict(
      244│             depth_first_search(
      245│                 PackageNode(self._package, packages), aggregate_package_nodes

  • Check your dependencies Python requirement: The Python requirement can be specified via the `python` or `markers` properties

    For questionary, a possible solution would be to set the `python` property to ">=3.6.1,<3.9"

    https://python-poetry.org/docs/dependency-specification/#python-restricted-dependencies,
    https://python-poetry.org/docs/dependency-specification/#using-environment-markers
```

Unless there's a strong reason to block python 3.9, I would advise to use this easier version specifier.

It's a matter of opinion of course, you're not forced to accept this.