### PR TITLE
Indicate the multiline input with \n>

### DIFF
--- a/questionary/constants.py
+++ b/questionary/constants.py
@@ -15,7 +15,7 @@ YES_OR_NO = "(Y/n)"
 NO_OR_YES = "(y/N)"
 
 # Instruction for multiline input
-INSTRUCTION_MULTILINE = "(Finish with 'Alt+Enter' or 'Esc, Enter')"
+INSTRUCTION_MULTILINE = "(Finish with 'Alt+Enter' or 'Esc, Enter')\n>"
 
 # Selection token used to indicate the selection cursor in a list
 SELECTED_POINTER = "»"


### PR DESCRIPTION
This feels more natural because multiline prompts usually start at the beginning of the terminal somehow. In a long question, the answer could start too far in the right side, and next lines too.

Of course, it can be overriden with the `instruction` parameter of the `text` prompt, so I'm just supplying a saner default.