### PR TITLE
Use arrow keys and shortcuts simultaneously

### DIFF
--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -156,6 +156,7 @@ class InquirerControl(FormattedTextControl):
     selected_options: List[Any]
     use_indicator: bool
     use_shortcuts: bool
+    use_arrow_keys: bool
     use_pointer: bool
     pointed_at: int
     is_answered: bool
@@ -166,6 +167,7 @@ class InquirerControl(FormattedTextControl):
         default: Optional[Union[str, Choice, Dict[str, Any]]] = None,
         use_indicator: bool = True,
         use_shortcuts: bool = False,
+        use_arrow_keys: bool = True,
         use_pointer: bool = True,
         initial_choice: Optional[Union[str, Choice, Dict[str, Any]]] = None,
         **kwargs: Any,
@@ -173,6 +175,7 @@ class InquirerControl(FormattedTextControl):
 
         self.use_indicator = use_indicator
         self.use_shortcuts = use_shortcuts
+        self.use_arrow_keys = use_arrow_keys
         self.use_pointer = use_pointer
         self.default = default
 

--- a/questionary/prompts/rawselect.py
+++ b/questionary/prompts/rawselect.py
@@ -40,5 +40,5 @@ def rawselect(
         Question: Question instance, ready to be prompted (using `.ask()`).
     """
     return select.select(
-        message, choices, default, qmark, style, use_shortcuts=True, **kwargs
+        message, choices, default, qmark, style, use_shortcuts=True, use_arrow_keys=False, **kwargs
     )

--- a/questionary/prompts/rawselect.py
+++ b/questionary/prompts/rawselect.py
@@ -40,5 +40,12 @@ def rawselect(
         Question: Question instance, ready to be prompted (using `.ask()`).
     """
     return select.select(
-        message, choices, default, qmark, style, use_shortcuts=True, use_arrow_keys=False, **kwargs
+        message,
+        choices,
+        default,
+        qmark,
+        style,
+        use_shortcuts=True,
+        use_arrow_keys=False,
+        **kwargs,
     )

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -145,6 +145,7 @@ def select(
             _reg_binding(i, c.shortcut_key)
 
     if use_arrow_keys or use_shortcuts is False:
+
         @bindings.add(Keys.Down, eager=True)
         @bindings.add("j", eager=True)
         def move_cursor_down(event):

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -18,6 +18,7 @@ def select(
     qmark: str = DEFAULT_QUESTION_PREFIX,
     style: Optional[Style] = None,
     use_shortcuts: bool = False,
+    use_arrow_keys: bool = True,
     use_indicator: bool = False,
     use_pointer: bool = True,
     instruction: Optional[str] = None,
@@ -43,8 +44,9 @@ def select(
                By default this is a `?`
 
         instruction: A hint on how to navigate the menu.
-                     It's `(Use arrow keys)` if `use_shortcuts` is not set
-                     to True and`(Use shortcuts)` otherwise by default
+                     It's `(Use shortcuts)` if only `use_shortcuts` is set
+                     to True, `(Use arrow keys or shortcuts)` `use_arrow_keys`
+                     & `use_shortcuts` are set and `(Use arrow keys)` by default.
 
         style: A custom color and style for the question parts. You can
                configure colors as well as font types for different elements.
@@ -56,6 +58,8 @@ def select(
         use_shortcuts: Allow the user to select items from the list using
                        shortcuts. The shortcuts will be displayed in front of
                        the list items.
+
+        use_arrow_keys: Allow usage of arrow keys to select item.
 
         use_pointer: Flag to enable the pointer in front of the currently
                      highlighted element.
@@ -82,6 +86,7 @@ def select(
         default,
         use_indicator=use_indicator,
         use_shortcuts=use_shortcuts,
+        use_arrow_keys=use_arrow_keys,
         use_pointer=use_pointer,
         initial_choice=default,
     )
@@ -104,12 +109,13 @@ def select(
             if instruction:
                 tokens.append(("class:instruction", instruction))
             else:
-                tokens.append(
-                    (
-                        "class:instruction",
-                        " (Use shortcuts)" if use_shortcuts else " (Use arrow keys)",
-                    )
-                )
+                if use_shortcuts and use_arrow_keys:
+                    instruction_msg = " (Use shortcuts or arrow keys)"
+                elif use_shortcuts and not use_arrow_keys:
+                    instruction_msg = " (Use shortcuts)"
+                else:
+                    instruction_msg = " (Use arrow keys)"
+                tokens.append(("class:instruction", instruction_msg))
 
         return tokens
 
@@ -137,8 +143,8 @@ def select(
                     ic.pointed_at = i
 
             _reg_binding(i, c.shortcut_key)
-    else:
 
+    if use_arrow_keys or use_shortcuts is False:
         @bindings.add(Keys.Down, eager=True)
         @bindings.add("j", eager=True)
         def move_cursor_down(event):

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -45,7 +45,7 @@ def select(
 
         instruction: A hint on how to navigate the menu.
                      It's `(Use shortcuts)` if only `use_shortcuts` is set
-                     to True, `(Use arrow keys or shortcuts)` `use_arrow_keys`
+                     to True, `(Use arrow keys or shortcuts)` if `use_arrow_keys`
                      & `use_shortcuts` are set and `(Use arrow keys)` by default.
 
         style: A custom color and style for the question parts. You can

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -172,3 +172,56 @@ def test_select_initial_choice_non_existant():
 
     with pytest.raises(ValueError):
         feed_cli_with_input("select", message, text, **kwargs)
+
+
+def test_select_arrow_keys():
+    message = "Foo message"
+    kwargs = {"choices": ["foo", "bazz"], "use_arrow_keys": True}
+    text = KeyInputs.DOWN + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("select", message, text, **kwargs)
+    assert result == "bazz"
+
+
+def test_select_shortcuts():
+    message = "Foo message"
+    kwargs = {"choices": ["foo", "bazz"], "use_shortcuts": True}
+    text = "2" + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("select", message, text, **kwargs)
+    assert result == "bazz"
+
+
+def test_select_no_arrow_keys():
+    message = "Foo message"
+    kwargs = {
+        "choices": ["foo", "bazz"],
+        "use_arrow_keys": False,
+        "use_shortcuts": True,
+    }
+    text = KeyInputs.DOWN + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("select", message, text, **kwargs)
+    assert result == "foo"
+
+
+def test_select_no_shortcuts():
+    message = "Foo message"
+    kwargs = {
+        "choices": ["foo", "bazz"],
+        "use_arrow_keys": True,
+        "use_shortcuts": False,
+    }
+    text = "2" + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("select", message, text, **kwargs)
+    assert result == "foo"
+
+
+def test_select_default_has_arrow_keys():
+    message = "Foo message"
+    kwargs = {"choices": ["foo", "bazz"]}
+    text = KeyInputs.DOWN + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("select", message, text, **kwargs)
+    assert result == "bazz"


### PR DESCRIPTION
I needed shortcuts and arrow key item selection at the same time.

This small patch allows to do so by setting select(use_arrow_keys=True, use_shortcuts=True). Backwards compatible and not touching default behaviour (hopefully).
