### PR TITLE
Fix double space between question and instructions in `confirm`

### DIFF
--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -91,7 +91,7 @@ def checkbox(
         if ic.is_answered:
             nbr_selected = len(ic.selected_options)
             if nbr_selected == 0:
-                tokens.append(("class:answer", " done"))
+                tokens.append(("class:answer", "done"))
             elif nbr_selected == 1:
                 if isinstance(ic.get_selected_values()[0].title, list):
                     ts = ic.get_selected_values()[0].title
@@ -110,13 +110,13 @@ def checkbox(
                     )
             else:
                 tokens.append(
-                    ("class:answer", " done ({} selections)".format(nbr_selected))
+                    ("class:answer", "done ({} selections)".format(nbr_selected))
                 )
         else:
             tokens.append(
                 (
                     "class:instruction",
-                    " (Use arrow keys to move, "
+                    "(Use arrow keys to move, "
                     "<space> to select, "
                     "<a> to toggle, "
                     "<i> to invert)",

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -105,7 +105,7 @@ def checkbox(
                     tokens.append(
                         (
                             "class:answer",
-                            " [{}]".format(ic.get_selected_values()[0].title),
+                            "[{}]".format(ic.get_selected_values()[0].title),
                         )
                     )
             else:

--- a/questionary/prompts/confirm.py
+++ b/questionary/prompts/confirm.py
@@ -56,10 +56,10 @@ def confirm(
         tokens.append(("class:question", " {} ".format(message)))
 
         if status["answer"] is not None:
-            answer = " {}".format(YES if status["answer"] else NO)
+            answer = YES if status["answer"] else NO
             tokens.append(("class:answer", answer))
         else:
-            instruction = " {}".format(YES_OR_NO if default else NO_OR_YES)
+            instruction = YES_OR_NO if default else NO_OR_YES
             tokens.append(("class:instruction", instruction))
 
         return to_formatted_text(tokens)

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -107,17 +107,17 @@ def select(
                     )
                 )
             else:
-                tokens.append(("class:answer", " " + ic.get_pointed_at().title))
+                tokens.append(("class:answer", ic.get_pointed_at().title))
         else:
             if instruction:
                 tokens.append(("class:instruction", instruction))
             else:
                 if use_shortcuts and use_arrow_keys:
-                    instruction_msg = " (Use shortcuts or arrow keys)"
+                    instruction_msg = "(Use shortcuts or arrow keys)"
                 elif use_shortcuts and not use_arrow_keys:
-                    instruction_msg = " (Use shortcuts)"
+                    instruction_msg = "(Use shortcuts)"
                 else:
-                    instruction_msg = " (Use arrow keys)"
+                    instruction_msg = "(Use arrow keys)"
                 tokens.append(("class:instruction", instruction_msg))
 
         return tokens


### PR DESCRIPTION
At the moment, there are two spaces printed between a message and the instructions (Y/n) or answer in a `confirm dialog`.  This PR removes one of those spaces.

If the double spaces are intentional, feel free to close.