### PR TITLE
Change checkbox validation API to match other prompts

### DIFF
--- a/examples/checkbox_toppings.py
+++ b/examples/checkbox_toppings.py
@@ -6,7 +6,9 @@ if __name__ == "__main__":
         questionary.checkbox(
             "Select toppings",
             choices=["foo", "bar", "bazz"],
-            validate=lambda a: (len(a) != 0, "You must select at least one topping"),
+            validate=lambda a: (
+                True if len(a) > 0 else "You must select at least one topping"
+            ),
             style=custom_style_dope,
         ).ask()
         or []

--- a/questionary/constants.py
+++ b/questionary/constants.py
@@ -30,6 +30,9 @@ DEFAULT_QUESTION_PREFIX = "?"
 # Message shown when a user aborts a question prompt using CTRL-C
 DEFAULT_KBI_MESSAGE = "Cancelled by user"
 
+# Default text shown when the input is invalid
+INVALID_INPUT = "Invalid input"
+
 # Default message style
 DEFAULT_STYLE = Style(
     [

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -17,6 +17,7 @@ from questionary.constants import (
     SELECTED_POINTER,
     INDICATOR_SELECTED,
     INDICATOR_UNSELECTED,
+    INVALID_INPUT,
 )
 
 # This is a cut-down version of `prompt_toolkit.formatted_text.AnyFormattedText`
@@ -410,7 +411,7 @@ def build_validator(validate: Any) -> Optional[Validator]:
                     verdict = validate(document.text)
                     if verdict is not True:
                         if verdict is False:
-                            verdict = "invalid input"
+                            verdict = INVALID_INPUT
                         raise ValidationError(
                             message=verdict, cursor_position=len(document.text)
                         )

--- a/tests/prompts/test_checkbox.py
+++ b/tests/prompts/test_checkbox.py
@@ -225,7 +225,7 @@ def test_validate_with_message():
     message = "Foo message"
     kwargs = {
         "choices": ["foo", "bar", "bazz"],
-        "validate": lambda a: (len(a) != 0, "Error Message"),
+        "validate": lambda a: True if len(a) > 0 else "Error Message",
     }
     text = KeyInputs.ENTER + "i" + KeyInputs.ENTER + "\r"
 

--- a/tests/prompts/test_common.py
+++ b/tests/prompts/test_common.py
@@ -40,7 +40,7 @@ def test_validator_bool_function_fails():
     with pytest.raises(ValidationError) as e:
         validator.validate(Document("fooooo"))
 
-    assert e.value.message == "invalid input"
+    assert e.value.message == "Invalid input"
 
 
 def test_validator_instance():


### PR DESCRIPTION
In #48 I added validation for checkboxes. I didn't realise until writing documentation that this API is not consistent with the function validation for other prompts (although having re-read the comments in the initial review, I think @tmbo did notice!). This PR makes validation for checkboxes consistent with other prompts (when using a function validator).