### PR TITLE
Use direct image URLs in README so that they show on PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 * [Support](#support)
 
 
-![Example](https://github.com/tmbo/questionary/blob/master/docs/images/example.gif)
+![Example](https://raw.githubusercontent.com/tmbo/questionary/master/docs/images/example.gif)
 
 ```python3
 import questionary
@@ -44,7 +44,7 @@ questionary.path("Path to the projects version file").ask()
 
 Used and supported by
 
-[<img src="https://github.com/tmbo/questionary/blob/master/docs/images/rasa-logo.svg" width="200">](https://github.com/RasaHQ/rasa)
+[<img src="https://raw.githubusercontent.com/tmbo/questionary/master/docs/images/rasa-logo.svg" width="200">](https://github.com/RasaHQ/rasa)
 
 ## Features
 


### PR DESCRIPTION
The images in the README on PyPi are broken: https://pypi.org/project/questionary/

Using direct URLs should fix this.