### PR TITLE
Switch to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = [ "poetry>=1.0.5",]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
[`poetry-core`](https://github.com/python-poetry/poetry-core) contains the build backend part of `poetry`.