### PR TITLE
Remove Poetry includes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers=[
     "Topic :: Software Development :: Libraries",
 ]
 keywords = [ "cli", "ui", "inquirer", "questions", "prompt",]
-include = [ "LICENSE", "README.md", "questionary/py.typed",]
 readme = "README.md"
 license = "MIT"
 


### PR DESCRIPTION
These were being included in the wheel and ultimately installed
in `site-packages` by pip, i.e. Poetry's readme and license would reside
in `site-packages/{LICENSE,README.md}.  To limit includes to the sdist
you would have to use the belatedly documented table format:
https://github.com/python-poetry/poetry/pull/2268/files.
However, the readme and the license are included by Poetry in the sdist
by default, and py.typed is included both in the wheel and the sdist
by default.  The include directive here is redundant.