### PR TITLE
Add additional tests to `select` and `checkbox`

### DIFF
--- a/tests/prompts/test_checkbox.py
+++ b/tests/prompts/test_checkbox.py
@@ -186,8 +186,28 @@ def test_list_ctr_c():
 
 def test_checkbox_initial_choice():
     message = "Foo message"
+    choice = Choice("bazz")
+    kwargs = {"choices": ["foo", choice], "initial_choice": choice}
+    text = KeyInputs.SPACE + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("checkbox", message, text, **kwargs)
+    assert result == ["bazz"]
+
+
+def test_select_initial_choice_string():
+    message = "Foo message"
     kwargs = {"choices": ["foo", "bazz"], "initial_choice": "bazz"}
     text = KeyInputs.SPACE + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("checkbox", message, text, **kwargs)
+    assert result == ["bazz"]
+
+
+def test_select_initial_choice_duplicate():
+    message = "Foo message"
+    choice = Choice("foo")
+    kwargs = {"choices": ["foo", choice, "bazz"], "initial_choice": choice}
+    text = KeyInputs.DOWN + KeyInputs.SPACE + KeyInputs.ENTER + "\r"
 
     result, cli = feed_cli_with_input("checkbox", message, text, **kwargs)
     assert result == ["bazz"]

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -148,8 +148,28 @@ def test_select_empty_choices():
 
 def test_select_initial_choice():
     message = "Foo message"
+    choice = Choice("bazz")
+    kwargs = {"choices": ["foo", choice], "default": choice}
+    text = KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("select", message, text, **kwargs)
+    assert result == "bazz"
+
+
+def test_select_initial_choice_string():
+    message = "Foo message"
     kwargs = {"choices": ["foo", "bazz"], "default": "bazz"}
     text = KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("select", message, text, **kwargs)
+    assert result == "bazz"
+
+
+def test_select_initial_choice_duplicate():
+    message = "Foo message"
+    choice = Choice("foo")
+    kwargs = {"choices": ["foo", choice, "bazz"], "default": choice}
+    text = KeyInputs.DOWN + KeyInputs.ENTER + "\r"
 
     result, cli = feed_cli_with_input("select", message, text, **kwargs)
     assert result == "bazz"


### PR DESCRIPTION
 - Test when a `Choice` instance is passed as `default` or `initial_choice`.
 - Test when a `Choice` instance and string have the same value and `default` or `initial_choice` is set to the `Choice` instance.

Adding these to catch some of the breaking changes that would be introduced by #130.