### PR TITLE
Fix highlighting in the questions of type select.

### DIFF
--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -254,8 +254,12 @@ class InquirerControl(FormattedTextControl):
             )
 
     def _is_selected(self, choice: Choice):
+        if isinstance(self.default, Choice):
+            compare_default = self.default == choice
+        else:
+            compare_default = self.default == choice.value
         return (
-            choice.checked or choice.value == self.default and self.default is not None
+            choice.checked or compare_default and self.default is not None
         ) and not choice.disabled
 
     def _assign_shortcut_keys(self):


### PR DESCRIPTION
issue #132 mentions an error in the highlighting of select type questions.

This error occurs when the default value is an object of type Choice because the condition being evaluated does not make a good comparison to know which option to highlight.

this is a quick, simple and functional fix that does not affect the rest of the operation.