### PR TITLE
Fix incorrect install target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ clean:
 	rm -rf dist/
 
 install:
-	poetry install
+	poetry install --extras "docs"
 
 formatter:
 	poetry run black .


### PR DESCRIPTION
Without this, the `make docs` command does not work.