### PR TITLE
Fix failing Coveralls CI

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -93,11 +93,24 @@ jobs:
       run: make test
 
     - name: Send Coverage Report 📊
-      if: matrix.python-version == 3.6 && matrix.os != 'windows-latest'
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_SERVICE_NAME: github
+        COVERALLS_PARALLEL: true
       run: poetry run coveralls
+
+  post-test:
+    name: Signal test completion
+    needs: test
+    runs-on: ubuntu-latest
+    container: python:3-slim
+    steps:
+    - name: Finished
+      run: |
+        pip3 install --upgrade coveralls
+        coveralls --service=github --finish
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docs:
     name: Test Docs


### PR DESCRIPTION
Coveralls tests usually fail when new PRs are submitted (it says the coverage has decreased).

I think this is because two coverage reports are being uploaded (one for Prompt Toolkit v2 and v3) without the `COVERALLS_PARALLEL` flag being set.

This PR uploads all coverage reports and indicates to Coveralls that they should be merged.

@tmbo I think the following check should also be added as required when this is merged: https://github.com/tmbo/questionary/pull/158/checks?check_run_id=3395118300