### PR TITLE
Upgrade Sphinx to v4

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,16 +1,13 @@
 version: 2
 
-sphinx:
-  configuration: docs/source/conf.py
-
 formats:
   - pdf
 
 sphinx:
+  configuration: docs/conf.py
   fail_on_warning: true
 
 python:
-  version: 3.7
   install:
     - method: pip
       path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,13 +1,11 @@
-import json
 import os
 import sys
-import traceback
 
 sys.path.insert(0, os.path.abspath("../"))
 from questionary import __version__
 
 project = "Questionary"
-copyright = "2020, Questionary"
+copyright = "2021, Questionary"
 author = "Questionary"
 
 version = __version__
@@ -20,12 +18,6 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_copybutton",
     "sphinx_autodoc_typehints",
-]
-
-nitpick_ignore = [
-    ("py:class", "questionary.prompts.common.Choice"),
-    ("py:class", "questionary.question.Question"),
-    ("py:class", "questionary.form.Form"),
 ]
 
 autodoc_typehints = "description"
@@ -41,50 +33,10 @@ html_theme_options = {
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "prompt_toolkit": ("https://python-prompt-toolkit.readthedocs.io/en/master/", None),
+    "prompt_toolkit": (
+        "https://prompt-toolkit-test.readthedocs.io/en/upgrade-sphinx",
+        None,
+    ),
 }
 
 autodoc_member_order = "alphabetical"
-
-# TODO: remove as soon as we upgrade to sphinx 4.0
-# Borrowed from https://github.com/sphinx-doc/sphinx/issues/5603
-intersphinx_aliases = {
-    ("py:class", "prompt_toolkit.styles.style.Style"): (
-        "py:class",
-        "prompt_toolkit.styles.Style",
-    ),
-    ("py:class", "prompt_toolkit.shortcuts.prompt.CompleteStyle"): (
-        "py:class",
-        "prompt_toolkit.shortcuts.CompleteStyle",
-    ),
-    ("py:class", "prompt_toolkit.completion.base.Completer"): (
-        "py:class",
-        "prompt_toolkit.completion.Completer",
-    ),
-    ("py:class", "prompt_toolkit.lexers.base.Lexer"): (
-        "py:class",
-        "prompt_toolkit.lexers.Lexer",
-    ),
-}
-
-
-def add_intersphinx_aliases_to_inv(app):
-    from sphinx.ext.intersphinx import InventoryAdapter
-
-    inventories = InventoryAdapter(app.builder.env)
-
-    for alias, target in app.config.intersphinx_aliases.items():
-        alias_domain, alias_name = alias
-        target_domain, target_name = target
-
-        try:
-            found = inventories.main_inventory[target_domain][target_name]
-            inventories.main_inventory[alias_domain][alias_name] = found
-        except KeyError as e:
-            traceback.print_exc()
-            continue
-
-
-def setup(app):
-    app.add_config_value("intersphinx_aliases", {}, "env")
-    app.connect("builder-inited", add_intersphinx_aliases_to_inv)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,10 +33,7 @@ html_theme_options = {
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "prompt_toolkit": (
-        "https://prompt-toolkit-test.readthedocs.io/en/upgrade-sphinx",
-        None,
-    ),
+    "prompt_toolkit": ("https://python-prompt-toolkit.readthedocs.io/en/master/", None),
 }
 
 autodoc_member_order = "alphabetical"

--- a/docs/pages/api_reference.rst
+++ b/docs/pages/api_reference.rst
@@ -16,6 +16,9 @@ API Reference
 .. autoclass:: questionary::Separator
    :members:
 
+.. autoclass:: questionary::FormField
+   :members:
+
 .. automethod:: questionary::form
 
 .. automethod:: questionary::prompt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-sphinx==2.4.4
-sphinx_rtd_theme==0.5.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -434,17 +434,17 @@ python-versions = "*"
 
 [[package]]
 name = "sphinx"
-version = "3.4.0"
+version = "4.1.2"
 description = "Python documentation generator"
 category = "main"
 optional = true
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 alabaster = ">=0.7,<0.8"
 babel = ">=1.3"
 colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
-docutils = ">=0.12"
+docutils = ">=0.14,<0.18"
 imagesize = "*"
 Jinja2 = ">=2.3"
 packaging = "*"
@@ -453,14 +453,14 @@ requests = ">=2.5.0"
 snowballstemmer = ">=1.1"
 sphinxcontrib-applehelp = "*"
 sphinxcontrib-devhelp = "*"
-sphinxcontrib-htmlhelp = "*"
+sphinxcontrib-htmlhelp = ">=2.0.0"
 sphinxcontrib-jsmath = "*"
 sphinxcontrib-qthelp = "*"
-sphinxcontrib-serializinghtml = "*"
+sphinxcontrib-serializinghtml = ">=1.1.5"
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-lint = ["flake8 (>=3.5.0)", "isort", "mypy (>=0.790)", "docutils-stubs"]
+lint = ["flake8 (>=3.5.0)", "isort", "mypy (>=0.900)", "docutils-stubs", "types-typed-ast", "types-pkg-resources", "types-requests"]
 test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
 
 [[package]]
@@ -550,11 +550,11 @@ test = ["pytest"]
 
 [[package]]
 name = "sphinxcontrib-htmlhelp"
-version = "1.0.3"
+version = "2.0.0"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 category = "main"
 optional = true
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
@@ -585,7 +585,7 @@ test = ["pytest"]
 
 [[package]]
 name = "sphinxcontrib-serializinghtml"
-version = "1.1.4"
+version = "1.1.5"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
 category = "main"
 optional = true
@@ -666,7 +666,7 @@ docs = ["Sphinx", "sphinx-rtd-theme", "sphinx-autobuild", "sphinx-copybutton", "
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "6ee5543d419c297dac2e33644ab777f5464856fad9a383c1793978d84846de2a"
+content-hash = "6ede842136c4863815a9a3834f1aadc82826b628f9caf1fe798d3183c57bfb91"
 
 [metadata.files]
 alabaster = [
@@ -983,8 +983,8 @@ snowballstemmer = [
     {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
 ]
 sphinx = [
-    {file = "Sphinx-3.4.0-py3-none-any.whl", hash = "sha256:77c801947eb86457822e01eadd5c2e2de020db0201f1f9fc98b0927980b6d212"},
-    {file = "Sphinx-3.4.0.tar.gz", hash = "sha256:4dcde313801f23ea4789ac31e5405e240cb758b5d375804807f2f3cc3c396bfa"},
+    {file = "Sphinx-4.1.2-py3-none-any.whl", hash = "sha256:46d52c6cee13fec44744b8c01ed692c18a640f6910a725cbb938bc36e8d64544"},
+    {file = "Sphinx-4.1.2.tar.gz", hash = "sha256:3092d929cd807926d846018f2ace47ba2f3b671b309c7a89cd3306e80c826b13"},
 ]
 sphinx-autobuild = [
     {file = "sphinx-autobuild-2021.3.14.tar.gz", hash = "sha256:de1ca3b66e271d2b5b5140c35034c89e47f263f2cd5db302c9217065f7443f05"},
@@ -1011,8 +1011,8 @@ sphinxcontrib-devhelp = [
     {file = "sphinxcontrib_devhelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e"},
 ]
 sphinxcontrib-htmlhelp = [
-    {file = "sphinxcontrib-htmlhelp-1.0.3.tar.gz", hash = "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"},
-    {file = "sphinxcontrib_htmlhelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f"},
+    {file = "sphinxcontrib-htmlhelp-2.0.0.tar.gz", hash = "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"},
+    {file = "sphinxcontrib_htmlhelp-2.0.0-py2.py3-none-any.whl", hash = "sha256:d412243dfb797ae3ec2b59eca0e52dac12e75a241bf0e4eb861e450d06c6ed07"},
 ]
 sphinxcontrib-jsmath = [
     {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
@@ -1023,8 +1023,8 @@ sphinxcontrib-qthelp = [
     {file = "sphinxcontrib_qthelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"},
 ]
 sphinxcontrib-serializinghtml = [
-    {file = "sphinxcontrib-serializinghtml-1.1.4.tar.gz", hash = "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc"},
-    {file = "sphinxcontrib_serializinghtml-1.1.4-py2.py3-none-any.whl", hash = "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"},
+    {file = "sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"},
+    {file = "sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 prompt_toolkit = ">=2.0,<4.0"
-Sphinx = {version = "^3.3", optional = true}
+Sphinx = {version = "^4.1", optional = true}
 sphinx-rtd-theme = {version = "^0.5.0", optional = true}
 sphinx-autobuild = {version = ">=2020.9.1,<2022.0.0", optional = true}
 sphinx-copybutton = {version = ">=0.3.1,<0.5.0", optional = true}

--- a/questionary/__init__.py
+++ b/questionary/__init__.py
@@ -3,11 +3,9 @@ from prompt_toolkit.validation import Validator, ValidationError
 from prompt_toolkit.styles import Style
 
 import questionary.version
-from questionary.form import Form
-from questionary.form import form
+from questionary.form import FormField, Form, form
 from questionary.prompt import prompt, unsafe_prompt
-from questionary.prompts.common import Choice
-from questionary.prompts.common import Separator
+from questionary.prompts.common import Choice, Separator
 from questionary.prompts.common import print_formatted_text as print
 from questionary.question import Question
 
@@ -42,6 +40,7 @@ __all__ = [
     "unsafe_prompt",
     # commonly used classes
     "Form",
+    "FormField",
     "Question",
     "Choice",
     "Style",

--- a/questionary/form.py
+++ b/questionary/form.py
@@ -5,6 +5,14 @@ from questionary.question import Question
 
 
 class FormField(NamedTuple):
+    """
+    Represents a question within a form
+
+    Args:
+        key: The name of the form field.
+        question: The question to ask in the form field.
+    """
+
     key: str
     question: Question
 


### PR DESCRIPTION
I have had to change the URL used for `prompt_toolkit` in the intersphinx mapping. The problem is described in this PR: prompt-toolkit/python-prompt-toolkit#1485.

Probably best to wait a few days before this PR is merged in case prompt-toolkit/python-prompt-toolkit#1485 is merged quickly. If not, we can merge this and change the URL back once prompt-toolkit/python-prompt-toolkit#1485 is merged.

This PR will make #152 redundant.