### PR TITLE
Remove test preventing CI from completing on Windows with `prompt_toolkit` `2.*`

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -60,10 +60,6 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
         promttoolkit: [3.*, 2.*]
-        exclude:
-          # tests on windows with prompt-toolkit 2.* do not complete
-          - os: windows-latest
-            promttoolkit: 2.*
 
     steps:
     - name: Checkout git repository 🕝

--- a/tests/test_question.py
+++ b/tests/test_question.py
@@ -1,10 +1,13 @@
 import asyncio
+import pytest
+import platform
 
 from prompt_toolkit.input.defaults import create_pipe_input
 from prompt_toolkit.output import DummyOutput
 from pytest import fail
 
 from questionary import text
+from questionary.utils import is_prompt_toolkit_3
 from tests.utils import KeyInputs
 
 
@@ -51,6 +54,10 @@ def test_skipping_of_skipping_of_questions():
         inp.close()
 
 
+@pytest.mark.skipif(
+    not is_prompt_toolkit_3() and platform.system() == "Windows",
+    reason="requires prompt_toolkit >= 3",
+)
 def test_async_ask_question():
     loop = asyncio.new_event_loop()
 


### PR DESCRIPTION
These checks should also be added to the list of required checks