### PR TITLE
Allow a custom completer to be used in a path prompt

### DIFF
--- a/docs/pages/api_reference.rst
+++ b/docs/pages/api_reference.rst
@@ -16,6 +16,9 @@ API Reference
 .. autoclass:: questionary::Separator
    :members:
 
+.. autoclass:: questionary::FilteredPathCompleter
+   :members:
+
 .. automethod:: questionary::form
 
 .. automethod:: questionary::prompt

--- a/questionary/__init__.py
+++ b/questionary/__init__.py
@@ -16,7 +16,7 @@ from questionary.prompts.autocomplete import autocomplete
 from questionary.prompts.select import select
 from questionary.prompts.checkbox import checkbox
 from questionary.prompts.text import text
-from questionary.prompts.path import path
+from questionary.prompts.path import path, FilteredPathCompleter
 from questionary.prompts.confirm import confirm
 from questionary.prompts.password import password
 from questionary.prompts.rawselect import rawselect
@@ -48,4 +48,5 @@ __all__ = [
     "Separator",
     "Validator",
     "ValidationError",
+    "FilteredPathCompleter",
 ]

--- a/tests/prompts/test_path.py
+++ b/tests/prompts/test_path.py
@@ -3,6 +3,7 @@ import prompt_toolkit
 import pytest
 
 from tests.utils import KeyInputs, feed_cli_with_input
+from prompt_toolkit.completion import Completer, Completion
 
 
 @pytest.fixture
@@ -76,3 +77,22 @@ def test_complete_path_directories_only(path_completion_tree):
 
     result, cli = feed_cli_with_input("path", message, texts, only_directories=True)
     assert result == str(path_completion_tree / "foo" / "buz")
+
+
+@pytest.mark.skipif(
+    prompt_toolkit.__version__.startswith("2"), reason="requires prompt toolkit >= 3.0"
+)
+def test_complete_custom_completer():
+    test_path = "foobar"
+
+    class CustomCompleter(Completer):
+        def get_completions(self, _, __):
+            yield Completion(test_path)
+
+    message = "Pick your path"
+    texts = ["baz", KeyInputs.TAB + KeyInputs.ENTER, KeyInputs.ENTER]
+
+    result, cli = feed_cli_with_input(
+        "path", message, texts, completer=CustomCompleter()
+    )
+    assert result == "baz" + test_path


### PR DESCRIPTION
**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->

Allow users to pass a custom `completer` to the `path` prompt.

Closes #127 and partially addresses #120 (which I will finish in another PR).

**How did you solve it?**
<!-- A detailed description of your implementation. -->

- Add an additional option to the `path` prompt, which allows a custom completer to be passed.
- Update the documentation.
- Add a unit test.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
