### PR TITLE
Fix order of question-config-properties in unsafe_prompt()

### DIFF
--- a/questionary/prompt.py
+++ b/questionary/prompt.py
@@ -137,10 +137,6 @@ def unsafe_prompt(
         if "name" not in question_config:
             raise PromptParameterException("name")
 
-        choices = question_config.get("choices")
-        if choices is not None and callable(choices):
-            question_config["choices"] = choices(answers)
-
         _kwargs = kwargs.copy()
         _kwargs.update(question_config)
 
@@ -166,6 +162,11 @@ def unsafe_prompt(
                 raise ValueError(
                     "'when' needs to be function that accepts a dict argument"
                 )
+
+        choices = question_config.get("choices")
+        if choices is not None and callable(choices):
+            question_config["choices"] = choices(answers)
+
         if _filter:
             # at least a little sanity check!
             if not callable(_filter):


### PR DESCRIPTION
**What is the problem that this PR addresses?**

When defining a prompt, the defined questions are processed in serial but the callable for the `Choices` is already called almost at the beginning. So `choices(answers)` is called always, even if it is unnecessary because the question should be skipped by condition.

Closes #112 

...

**How did you solve it?**

Move the execution of the `choices` callable AFTER the `when` -check. This way execution is prevented when question is skipped. This prevents side-effects and unnecessary delays when e.g. querying external resources.

...

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
