### PR TITLE
Question skip fix

### DIFF
--- a/questionary/question.py
+++ b/questionary/question.py
@@ -38,9 +38,6 @@ class Question:
             `Any`: The answer from the question.
         """
 
-        if self.should_skip_question:
-            return self.default
-
         try:
             sys.stdout.flush()
             return await self.unsafe_ask_async(patch_stdout)
@@ -63,9 +60,6 @@ class Question:
             `Any`: The answer from the question.
         """
 
-        if self.should_skip_question:
-            return self.default
-
         try:
             return self.unsafe_ask(patch_stdout)
         except KeyboardInterrupt:
@@ -84,6 +78,9 @@ class Question:
         Returns:
             `Any`: The answer from the question.
         """
+
+        if self.should_skip_question:
+            return self.default
 
         if patch_stdout:
             with prompt_toolkit.patch_stdout.patch_stdout():
@@ -118,6 +115,9 @@ class Question:
         Returns:
             `Any`: The answer from the question.
         """
+
+        if self.should_skip_question:
+            return self.default
 
         if not utils.ACTIVATED_ASYNC_MODE:
             await utils.activate_prompt_toolkit_async_mode()

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -15,6 +15,7 @@ def example_form(inp):
         ),
     )
 
+
 def example_form_with_skip(inp):
     return form(
         q1=questionary.confirm("Hello?", input=inp, output=DummyOutput()),

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -15,6 +15,14 @@ def example_form(inp):
         ),
     )
 
+def example_form_with_skip(inp):
+    return form(
+        q1=questionary.confirm("Hello?", input=inp, output=DummyOutput()),
+        q2=questionary.select(
+            "World?", choices=["foo", "bar"], input=inp, output=DummyOutput()
+        ).skip_if(True, 42),
+    )
+
 
 def test_form_creation():
     inp = create_pipe_input()
@@ -27,6 +35,36 @@ def test_form_creation():
         result = f.unsafe_ask()
 
         assert result == {"q1": True, "q2": "foo"}
+    finally:
+        inp.close()
+
+
+def test_form_skips_questions():
+    inp = create_pipe_input()
+    text = "Y" + KeyInputs.ENTER + "\r"
+
+    try:
+        inp.send_text(text)
+        f = example_form_with_skip(inp)
+
+        result = f.ask()
+
+        assert result == {"q1": True, "q2": 42}
+    finally:
+        inp.close()
+
+
+def test_form_skips_questions_unsafe_ask():
+    inp = create_pipe_input()
+    text = "Y" + KeyInputs.ENTER + "\r"
+
+    try:
+        inp.send_text(text)
+        f = example_form_with_skip(inp)
+
+        result = f.unsafe_ask()
+
+        assert result == {"q1": True, "q2": 42}
     finally:
         inp.close()
 

--- a/tests/test_question.py
+++ b/tests/test_question.py
@@ -63,6 +63,22 @@ def test_skipping_of_skipping_of_questions():
         inp.close()
 
 
+def test_skipping_of_skipping_of_questions_unsafe():
+    inp = create_pipe_input()
+    try:
+        inp.send_text("World" + KeyInputs.ENTER + "\r")
+
+        question = text("Hello?", input=inp, output=DummyOutput()).skip_if(
+            condition=False, default=42
+        )
+
+        response = question.unsafe_ask()
+
+        assert response == "World" and not response == 42
+    finally:
+        inp.close()
+
+
 def test_async_ask_question():
     loop = asyncio.new_event_loop()
 

--- a/tests/test_question.py
+++ b/tests/test_question.py
@@ -35,6 +35,18 @@ def test_skipping_of_questions():
         inp.close()
 
 
+def test_skipping_of_questions_unsafe():
+    inp = create_pipe_input()
+    try:
+        question = text("Hello?", input=inp, output=DummyOutput()).skip_if(
+            condition=True, default=42
+        )
+        response = question.unsafe_ask()
+        assert response == 42
+    finally:
+        inp.close()
+
+
 def test_skipping_of_skipping_of_questions():
     inp = create_pipe_input()
     try:


### PR DESCRIPTION
**What is the problem that this PR addresses?**
Two situations I tried to use today were having questions set up in a `form` where some of those questions could be skipped, and setting up my own `KeyboardInterrupt` and so needing to use `unsafe_ask`, again with questions that could be skipped.

In both of those instances, the questions would not skip.

**How did you solve it?**
In the `questions.py` the check for skipping:
```python
        if self.should_skip_question:
            return self.default
```
was in the `ask` and `ask_async` functions.  I moved this check to the `unsafe_ask` and `unsafe_ask_async` functions instead.

This has the effect of fixing the issue when trying to implement a `KeyboardInterrupt` handler (so needing to use the `unsafe_*` functions), but also allowing skipping in the `form` because that directly calls `unsafe_ask`.  It also allows `ask` and `ask_async` to continue to work as they also just proxy to the unsafe version of the functions.

I added another couple tests to `test_question.py` for the `unsafe` version of the skip question tests, and I added another couple to the `test_form.py` file for testing of skipping questions.

![image](https://user-images.githubusercontent.com/684421/143723159-1c3dbd96-cabb-45cb-aa44-e8c6f04da10d.png)


**Checklist**

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
