### PR TITLE
fix(types): declare support for single questions

### DIFF
--- a/questionary/prompt.py
+++ b/questionary/prompt.py
@@ -1,5 +1,5 @@
 from prompt_toolkit.output import ColorDepth
-from typing import Any, Dict, Optional, Iterable, Mapping
+from typing import Any, Dict, Optional, Iterable, Mapping, Union
 
 from questionary import utils
 from questionary.constants import DEFAULT_KBI_MESSAGE
@@ -13,7 +13,7 @@ class PromptParameterException(ValueError):
 
 
 def prompt(
-    questions: Iterable[Mapping[str, Any]],
+    questions: Union[Dict[str, Any], Iterable[Mapping[str, Any]]],
     answers: Optional[Mapping[str, Any]] = None,
     patch_stdout: bool = False,
     true_color: bool = False,
@@ -74,7 +74,7 @@ def prompt(
 
 
 def unsafe_prompt(
-    questions: Iterable[Mapping[str, Any]],
+    questions: Union[Dict[str, Any], Iterable[Mapping[str, Any]]],
     answers: Optional[Mapping[str, Any]] = None,
     patch_stdout: bool = False,
     true_color: bool = False,


### PR DESCRIPTION


**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->

Without this patch, when calling `prompt` or `unsafe_prompt` with a `dict` on `questions`, mypy fails with:

    Argument 1 to "unsafe_prompt" has incompatible type "Dict[str, Any]"; expected "Iterable[Mapping[str, Any]]"

**How did you solve it?**
<!-- A detailed description of your implementation. -->

As dict is a valid supported input, I added it to the typing information, joined within an `Union` type.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
