### PR TITLE
Return selected choices even if they are disabled

### DIFF
--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -258,9 +258,7 @@ class InquirerControl(FormattedTextControl):
             compare_default = self.default == choice
         else:
             compare_default = self.default == choice.value
-        return (
-            choice.checked or compare_default and self.default is not None
-        ) and not choice.disabled
+        return choice.checked or compare_default and self.default is not None
 
     def _assign_shortcut_keys(self):
         available_shortcuts = self.SHORTCUT_KEYS[:]


### PR DESCRIPTION
**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->

Choices which are selected but also disabled are not returned from a question. This PR changes this behaviour so that any selected choice (even if disabled) is returned.

Closes #187.

**How did you solve it?**
<!-- A detailed description of your implementation. -->

Removed check for the choice being disabled.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
