### PR TITLE
Support Emacs keys (Ctrl+N and Ctrl+P)

### DIFF
--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -29,7 +29,7 @@ def checkbox(
     initial_choice: Optional[Union[str, Choice, Dict[str, Any]]] = None,
     use_arrow_keys: bool = True,
     use_jk_keys: bool = True,
-    use_emacs_keys: bool = False,
+    use_emacs_keys: bool = True,
     **kwargs: Any,
 ) -> Question:
     """Ask the user to select from a list of items.

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -29,6 +29,7 @@ def checkbox(
     initial_choice: Optional[Union[str, Choice, Dict[str, Any]]] = None,
     use_arrow_keys: bool = True,
     use_jk_keys: bool = True,
+    use_emacs_keys: bool = False,
     **kwargs: Any,
 ) -> Question:
     """Ask the user to select from a list of items.
@@ -93,13 +94,17 @@ def checkbox(
         use_jk_keys: Allow the user to select items from the list using
                      `j` (down) and `k` (up) keys.
 
+        use_emacs_keys: Allow the user to select items from the list using
+                        `Ctrl+N` (down) and `Ctrl+P` (up) keys.
+
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).
     """
 
-    if not (use_arrow_keys or use_jk_keys):
+    if not (use_arrow_keys or use_jk_keys or use_emacs_keys):
         raise ValueError(
-            "Some option to move the selection is required. Arrow keys or j/k keys."
+            "Some option to move the selection is required. Arrow keys or j/k or "
+            "Emacs keys."
         )
 
     merged_style = merge_styles(
@@ -250,6 +255,10 @@ def checkbox(
     if use_jk_keys:
         bindings.add("j", eager=True)(move_cursor_down)
         bindings.add("k", eager=True)(move_cursor_up)
+
+    if use_emacs_keys:
+        bindings.add(Keys.ControlN, eager=True)(move_cursor_down)
+        bindings.add(Keys.ControlP, eager=True)(move_cursor_up)
 
     @bindings.add(Keys.ControlM, eager=True)
     def set_answer(event):

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -29,7 +29,7 @@ def select(
     use_arrow_keys: bool = True,
     use_indicator: bool = False,
     use_jk_keys: bool = True,
-    use_emacs_keys: bool = False,
+    use_emacs_keys: bool = True,
     show_selected: bool = False,
     instruction: Optional[str] = None,
     **kwargs: Any,

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -29,6 +29,7 @@ def select(
     use_arrow_keys: bool = True,
     use_indicator: bool = False,
     use_jk_keys: bool = True,
+    use_emacs_keys: bool = False,
     show_selected: bool = False,
     instruction: Optional[str] = None,
     **kwargs: Any,
@@ -99,14 +100,19 @@ def select(
                      `j` (down) and `k` (up) keys. Arrow keys, j/k keys and
                      shortcuts are not mutually exclusive.
 
+        use_emacs_keys: Allow the user to select items from the list using
+                        `Ctrl+N` (down) and `Ctrl+P` (up) keys. Arrow keys, j/k keys,
+                        emacs keys and shortcuts are not mutually exclusive.
+
         show_selected: Display current selection choice at the bottom of list.
 
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).
     """
-    if not (use_arrow_keys or use_shortcuts or use_jk_keys):
+    if not (use_arrow_keys or use_shortcuts or use_jk_keys or use_emacs_keys):
         raise ValueError(
-            "Some option to move the selection is required. Arrow keys, j/k keys or shortcuts."
+            "Some option to move the selection is required. Arrow keys, j/k keys, "
+            "emacs keys or shortcuts."
         )
 
     if use_shortcuts and use_jk_keys:
@@ -218,6 +224,10 @@ def select(
     if use_jk_keys:
         bindings.add("j", eager=True)(move_cursor_down)
         bindings.add("k", eager=True)(move_cursor_up)
+
+    if use_emacs_keys:
+        bindings.add(Keys.ControlN, eager=True)(move_cursor_down)
+        bindings.add(Keys.ControlP, eager=True)(move_cursor_up)
 
     @bindings.add(Keys.ControlM, eager=True)
     def set_answer(event):

--- a/tests/prompts/test_checkbox.py
+++ b/tests/prompts/test_checkbox.py
@@ -76,14 +76,30 @@ def test_select_first_and_third_choice():
     text = (
         KeyInputs.SPACE
         + KeyInputs.DOWN
-        + KeyInputs.SPACE
         + "j"
+        + KeyInputs.SPACE
         + KeyInputs.ENTER
         + "\r"
     )
 
     result, cli = feed_cli_with_input("checkbox", message, text, **kwargs)
-    assert result == ["foo", "bar"]
+    assert result == ["foo", "bazz"]
+
+
+def test_select_first_and_third_choice_using_emacs_keys():
+    message = "Foo message"
+    kwargs = {"choices": ["foo", "bar", "bazz"]}
+    text = (
+        KeyInputs.SPACE
+        + KeyInputs.CONTROLN
+        + KeyInputs.CONTROLN
+        + KeyInputs.SPACE
+        + KeyInputs.ENTER
+        + "\r"
+    )
+
+    result, cli = feed_cli_with_input("checkbox", message, text, **kwargs)
+    assert result == ["foo", "bazz"]
 
 
 def test_cycle_to_first_choice():
@@ -106,6 +122,15 @@ def test_cycle_backwards():
     message = "Foo message"
     kwargs = {"choices": ["foo", "bar", "bazz"]}
     text = KeyInputs.UP + KeyInputs.SPACE + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("checkbox", message, text, **kwargs)
+    assert result == ["bazz"]
+
+
+def test_cycle_backwards_using_emacs_keys():
+    message = "Foo message"
+    kwargs = {"choices": ["foo", "bar", "bazz"]}
+    text = KeyInputs.CONTROLP + KeyInputs.SPACE + KeyInputs.ENTER + "\r"
 
     result, cli = feed_cli_with_input("checkbox", message, text, **kwargs)
     assert result == ["bazz"]
@@ -308,6 +333,7 @@ def test_fail_on_no_method_to_move_selection():
         "use_shortcuts": False,
         "use_arrow_keys": False,
         "use_jk_keys": False,
+        "use_emacs_keys": False,
     }
     text = KeyInputs.ENTER + "\r"
 

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -76,6 +76,21 @@ def test_select_second_choice_using_j_k():
     assert result == "bar"
 
 
+def test_select_second_choice_using_emacs_keys():
+    message = "Foo message"
+    kwargs = {"choices": ["foo", "bar", "bazz"]}
+    text = (
+        KeyInputs.CONTROLN
+        + KeyInputs.CONTROLN
+        + KeyInputs.CONTROLP
+        + KeyInputs.ENTER
+        + "\r"
+    )
+
+    result, cli = feed_cli_with_input("select", message, text, **kwargs)
+    assert result == "bar"
+
+
 def test_select_with_instruction():
     message = "Foo message"
     kwargs = {"choices": ["foo", "bar", "bazz"], "instruction": "sample instruction"}
@@ -289,6 +304,7 @@ def test_fail_on_no_method_to_move_selection():
         "use_shortcuts": False,
         "use_arrow_keys": False,
         "use_jk_keys": False,
+        "use_emacs_keys": False,
     }
     text = KeyInputs.ENTER + "\r"
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,6 +17,8 @@ class KeyInputs:
     ENTER = "\r"
     ESCAPE = "\x1b"
     CONTROLC = "\x03"
+    CONTROLN = "\x0e"
+    CONTROLP = "\x10"
     BACK = "\x7f"
     SPACE = " "
     TAB = "\x09"


### PR DESCRIPTION
**What is the problem that this PR addresses?**

Emacs key bindings are not supported. Emacs use [Ctrl+N and Ctrl+P](https://en.wikipedia.org/wiki/Table_of_keyboard_shortcuts) for next and previous.
Most libraries support both Emacs and Vi style (e.g. Python Prompt Toolkit, [Readline](https://web.mit.edu/gnu/doc/html/rlman_1.html))

**How did you solve it?**

Add `use_emacs_keys` argument to `select` and `checkbox`.

**Checklist**

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.