### PR TITLE
Fix rendering error in the documentation

### DIFF
--- a/docs/pages/contributors.rst
+++ b/docs/pages/contributors.rst
@@ -81,6 +81,7 @@ Create a Command Line Recording
       $ npm install --global asciicast2gif
 
 2. Start the recording with ``asciinema``:
+
     .. code-block:: console
 
       $ asciinema rec
@@ -88,6 +89,7 @@ Create a Command Line Recording
 3. Do the thing you want to record.
 
 4. Convert to gif using ``asciicast2gif``:
+
     .. code-block:: console
 
       $ asciicast2gif -h 7 -w 120 -s 2 <recording> output.gif


### PR DESCRIPTION
**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->

There should be empty lines before code blocks, otherwise, the documentation is incorrectly rendered.

**How did you solve it?**
<!-- A detailed description of your implementation. -->

Added empty lines before two of the code blocks which were missing them.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
