### PR TITLE
Add missing Python version to CI matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -60,8 +60,10 @@ jobs:
         include:
           - promttoolkit: 3.0.29
             os: ubuntu-latest
+            python-version: '3.10'
           - promttoolkit: 3.0.19
             os: ubuntu-latest
+            python-version: '3.10'
 
     steps:
     - name: Checkout git repository 🕝


### PR DESCRIPTION
**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->

Fixes a problem introduced in #222.

Some custom entries in the CI matrix do not have an explicit Python version, which does not appear to be supported in later versions of the `setup-python` action.

This should allow #233 to be merged.

**How did you solve it?**
<!-- A detailed description of your implementation. -->

I added the Python version to all runs of the CI workflow.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
