### PR TITLE
Add a `print` question type

### DIFF
--- a/examples/advanced_workflow.py
+++ b/examples/advanced_workflow.py
@@ -7,6 +7,14 @@ from questionary import prompt
 def ask_dictstyle(**kwargs):
     questions = [
         {
+            # just print a message, don't ask a question
+            # does not require a name (but if provided, is ignored) and does not return a value
+            "type": "print",
+            "name": "intro",
+            "message": "This example demonstrates advanced features! 🦄",
+            "style": "bold italic",
+        },
+        {
             "type": "confirm",
             "name": "conditional_step",
             "message": "Would you like the next question?",
@@ -28,6 +36,14 @@ def ask_dictstyle(**kwargs):
             "choices": ["item1", "item2", Separator(), "other"],
         },
         {
+            # just print a message, don't ask a question
+            # does not require a name and does not return a value
+            "type": "print",
+            "message": "Please enter a value for 'other'",
+            "style": "bold italic fg:darkred",
+            "when": lambda x: x["second_question"] == "other",
+        },
+        {
             "type": "text",
             # intentionally overwrites result from previous question
             "name": "second_question",
@@ -35,7 +51,7 @@ def ask_dictstyle(**kwargs):
             "when": lambda x: x["second_question"] == "other",
         },
     ]
-    return prompt(questions)
+    return prompt(questions, **kwargs)
 
 
 if __name__ == "__main__":

--- a/questionary/prompt.py
+++ b/questionary/prompt.py
@@ -186,6 +186,8 @@ def unsafe_prompt(
             _kwargs.pop("input", None)
 
             print_formatted_text(message, **_kwargs)
+            if name:
+                answers[name] = None
             continue
 
         choices = question_config.get("choices")

--- a/questionary/prompt.py
+++ b/questionary/prompt.py
@@ -145,7 +145,7 @@ def unsafe_prompt(
         if "type" not in question_config:
             raise PromptParameterException("type")
         # every type except 'print' needs a name
-        if "name" not in question_config and question_config["type"] != "print": # noqa
+        if "name" not in question_config and question_config["type"] != "print":
             raise PromptParameterException("name")
 
         _kwargs = kwargs.copy()
@@ -153,7 +153,7 @@ def unsafe_prompt(
 
         _type = _kwargs.pop("type")
         _filter = _kwargs.pop("filter", None)
-        name = _kwargs.pop("name", None) if _type == "print" else _kwargs.pop("name") # noqa
+        name = _kwargs.pop("name", None) if _type == "print" else _kwargs.pop("name")
         when = _kwargs.pop("when", None)
 
         if true_color:

--- a/questionary/prompt.py
+++ b/questionary/prompt.py
@@ -145,7 +145,7 @@ def unsafe_prompt(
         if "type" not in question_config:
             raise PromptParameterException("type")
         # every type except 'print' needs a name
-        if "name" not in question_config and question_config["type"] != "print":
+        if "name" not in question_config and question_config["type"] != "print": # noqa
             raise PromptParameterException("name")
 
         _kwargs = kwargs.copy()
@@ -153,7 +153,7 @@ def unsafe_prompt(
 
         _type = _kwargs.pop("type")
         _filter = _kwargs.pop("filter", None)
-        name = _kwargs.pop("name", None) if _type == "print" else _kwargs.pop("name")
+        name = _kwargs.pop("name", None) if _type == "print" else _kwargs.pop("name") # noqa
         when = _kwargs.pop("when", None)
 
         if true_color:
@@ -181,8 +181,8 @@ def unsafe_prompt(
             except KeyError as e:
                 raise PromptParameterException("message") from e
 
-            # questions can take 'input' arg but print_formatted_text does not (it only outputs)
-            # Need to remove 'input', if present, to avoid breakage when testing or using custom input
+            # questions can take 'input' arg but print_formatted_text does not
+            # Remove 'input', if present, to avoid breaking during tests
             _kwargs.pop("input", None)
 
             print_formatted_text(message, **_kwargs)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -121,6 +121,7 @@ def test_advanced_workflow_example():
     result_dict = ask_with_patched_input(ask_dictstyle, text)
 
     assert result_dict == {
+        "intro": None,
         "conditional_step": True,
         "next_question": "questionary",
         "second_question": "Hello World",

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -101,3 +101,27 @@ def test_autocomplete_example():
 
     assert result_dict == {"ants": "Polyergus lucidus"}
     assert result_py == "Polyergus lucidus"
+
+
+def test_advanced_workflow_example():
+    from examples.advanced_workflow import ask_dictstyle
+
+    text = (
+        KeyInputs.ENTER
+        + "questionary"
+        + KeyInputs.ENTER
+        + KeyInputs.DOWN
+        + KeyInputs.DOWN
+        + KeyInputs.ENTER
+        + "Hello World"
+        + KeyInputs.ENTER
+        + "\r"
+    )
+
+    result_dict = ask_with_patched_input(ask_dictstyle, text)
+
+    assert result_dict == {
+        "conditional_step": True,
+        "next_question": "questionary",
+        "second_question": "Hello World",
+    }

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -63,5 +63,6 @@ def test_missing_print_message():
 
 
 def test_print_no_name():
-    """'print' type doesn't require a name so it should not throw PromptParameterException"""
+    """'print' type doesn't require a name so it
+    should not throw PromptParameterException"""
     assert prompt([{"type": "print", "message": "Hello World"}]) == {}

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -47,3 +47,21 @@ def test_invalid_question_type():
                 }
             ]
         )
+
+
+def test_missing_print_message():
+    """Test 'print' raises exception if missing 'message'"""
+    with pytest.raises(PromptParameterException):
+        prompt(
+            [
+                {
+                    "name": "test",
+                    "type": "print",
+                }
+            ]
+        )
+
+
+def test_print_no_name():
+    """'print' type doesn't require a name so it should not throw PromptParameterException"""
+    assert prompt([{"type": "print", "message": "Hello World"}]) == {}

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -69,3 +69,10 @@ def test_print_no_name():
     questions = [{"type": "print", "message": "Hello World"}]
     result = patched_prompt(questions, "")
     assert result == {}
+
+
+def test_print_with_name():
+    """'print' type should return {name: None} when name is provided"""
+    questions = [{"name": "hello", "type": "print", "message": "Hello World"}]
+    result = patched_prompt(questions, "")
+    assert result == {"hello": None}

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -2,6 +2,7 @@ import pytest
 
 from questionary.prompt import PromptParameterException
 from questionary.prompt import prompt
+from tests.utils import patched_prompt
 
 
 def test_missing_message():
@@ -65,4 +66,6 @@ def test_missing_print_message():
 def test_print_no_name():
     """'print' type doesn't require a name so it
     should not throw PromptParameterException"""
-    assert prompt([{"type": "print", "message": "Hello World"}]) == {}
+    questions = [{"type": "print", "message": "Hello World"}]
+    result = patched_prompt(questions, "")
+    assert result == {}


### PR DESCRIPTION
**What is the problem that this PR addresses?**
Adds `print` type to dictionary style prompts. Closes #207.

...

**How did you solve it?**
Modified `prompt()` to handle a `print` type that prints a message (with/without optional style).  The `name` field is optional when using `print`. `print` does not return a value and does not add an entry to the returned dict from `prompt()`; it only outputs text.  `print` does work with the `when` keyword so the message can be conditionally printed.

...

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [X] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [X] I will check that all automated PR checks pass before the PR gets reviewed.

Note: several tests in `tests/prompts/test_select.py` failed with "too many open files".  However, these same tests failed *before* the PR changes.  I'm using a Mac running Catalina 10.15.7. All other tests (including the tests added for this PR) passed.

```
tests/prompts/test_select.py::test_jk_and_shortcut_conflict_avoided_by_disabling_ij_keys FAILED                                                 [ 94%]
tests/prompts/test_select.py::test_select_shortcuts FAILED                                                                                      [ 95%]
tests/prompts/test_select.py::test_select_no_arrow_keys FAILED                                                                                  [ 95%]
tests/prompts/test_select.py::test_select_no_shortcuts FAILED                                                                                   [ 96%]
tests/prompts/test_select.py::test_select_default_has_arrow_keys FAILED
```

mypy checks passed:

```
mypy questionary
Success: no issues found in 17 source files
```

The `pycodestyle` test required by contributor's guide had many failures (mostly long lines) that were *already* present in the source code -- not changed in this PR.  I fixed the changes in the PR to ensure they introduced no new pycodestyle errors. I did add `# noqa` to two lines in `prompt.py` that were 80 and 85 lines long respectively because changing the code would have been much less clean (would require an if/then block instead of an inline which was easier to read).

Note: running black on the `tests/` directory would have changed a bunch of the existing import statements so I made sure my new tests were blackified but did not run black on the existing code.
