### PR TITLE
Add shortcuts to navigate Checkbox lists faster

### DIFF
--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -246,6 +246,30 @@ def checkbox(
 
         perform_validation(get_selected_values())
 
+    @bindings.add(Keys.End, eager=True)
+    def move_cursor_start(event):
+        ic.pointed_at = 0
+
+    @bindings.add(Keys.Home, eager=True)
+    def move_cursor_end(event):
+        ic.pointed_at = len(ic.choices) - 1
+
+    @bindings.add(Keys.PageDown, eager=True)
+    def move_cursor_down_fast(event):
+        for _ in range(10):
+            ic.select_next()
+
+        while not ic.is_selection_valid():
+            ic.select_next()
+
+    @bindings.add(Keys.PageUp, eager=True)
+    def move_cursor_up_fast(event):
+        for _ in range(10):
+            ic.select_previous()
+
+        while not ic.is_selection_valid():
+            ic.select_previous()
+
     def move_cursor_down(event):
         ic.select_next()
         while not ic.is_selection_valid():

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -246,11 +246,11 @@ def checkbox(
 
         perform_validation(get_selected_values())
 
-    @bindings.add(Keys.End, eager=True)
+    @bindings.add(Keys.Home, eager=True)
     def move_cursor_start(event):
         ic.pointed_at = 0
 
-    @bindings.add(Keys.Home, eager=True)
+    @bindings.add(Keys.End, eager=True)
     def move_cursor_end(event):
         ic.pointed_at = len(ic.choices) - 1
 


### PR DESCRIPTION
**What is the problem that this PR addresses?**
When offering a very long list of choices in the Checkbox question, traversing it is very slow.

**How did you solve it?**
I added four new bindings to the following keys:
- Home: Go to the first choice.
- End: Go to the last choice.
- NextPage: Advance 10 positions.
- LastPage: Go back 10 postions.

**Checklist**
- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
