### PR TITLE
Implement 'press any key to continue' prompt

### DIFF
--- a/docs/pages/types.rst
+++ b/docs/pages/types.rst
@@ -25,6 +25,8 @@ with the available question types**:
 
 * use :ref:`type_autocomplete` to ask for free text with **autocomplete help**
 
+* use :ref:`type_press_any_key_to_continue` to ask the user to **press any key to continue**
+
 .. _type_text:
 
 Text
@@ -85,3 +87,10 @@ Printing Formatted Text
 #######################
 
 .. automethod:: questionary::print
+
+.. _type_press_any_key_to_continue:
+
+Press Any Key To Continue
+#########################
+
+.. automethod:: questionary::press_any_key_to_continue

--- a/questionary/__init__.py
+++ b/questionary/__init__.py
@@ -19,6 +19,7 @@ from questionary.prompts.common import print_formatted_text as print
 from questionary.prompts.confirm import confirm
 from questionary.prompts.password import password
 from questionary.prompts.path import path
+from questionary.prompts.press_any_key_to_continue import press_any_key_to_continue
 from questionary.prompts.rawselect import rawselect
 from questionary.prompts.select import select
 from questionary.prompts.text import text
@@ -34,6 +35,7 @@ __all__ = [
     "confirm",
     "password",
     "path",
+    "press_any_key_to_continue",
     "rawselect",
     "select",
     "text",

--- a/questionary/prompts/__init__.py
+++ b/questionary/prompts/__init__.py
@@ -3,6 +3,7 @@ from questionary.prompts import checkbox
 from questionary.prompts import confirm
 from questionary.prompts import password
 from questionary.prompts import path
+from questionary.prompts import press_any_key_to_continue
 from questionary.prompts import rawselect
 from questionary.prompts import select
 from questionary.prompts import text
@@ -16,6 +17,7 @@ AVAILABLE_PROMPTS = {
     "password": password.password,
     "checkbox": checkbox.checkbox,
     "path": path.path,
+    "press_any_key_to_continue": press_any_key_to_continue.press_any_key_to_continue,
     # backwards compatible names
     "list": select.select,
     "rawlist": rawselect.rawselect,

--- a/questionary/prompts/press_any_key_to_continue.py
+++ b/questionary/prompts/press_any_key_to_continue.py
@@ -1,0 +1,61 @@
+from typing import Optional
+
+from prompt_toolkit import PromptSession
+from prompt_toolkit.formatted_text import to_formatted_text
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.keys import Keys
+from prompt_toolkit.styles import Style
+from prompt_toolkit.styles import merge_styles
+
+from questionary.constants import DEFAULT_STYLE
+from questionary.question import Question
+
+
+def press_any_key_to_continue(
+    message: Optional[str] = None,
+    style: Optional[Style] = None,
+    **kwargs,
+):
+    """Wait until user presses any key to continue.
+
+    Example:
+        >>> import questionary
+        >>> questionary.press_any_key_to_continue().ask()
+         Press any key to continue...
+        None
+
+    Args:
+        message: Question text. Defaults to `"Press any key to continue..."`
+
+        style: A custom color and style for the question parts. You can
+               configure colors as well as font types for different elements.
+
+    Returns:
+        :class:`Question`: Question instance, ready to be prompted (using `.ask()`).
+    """
+    merged_style = merge_styles([DEFAULT_STYLE, style])
+
+    if message is None:
+        message = ("Press any key to continue...",)
+
+    def get_prompt_tokens():
+        tokens = []
+
+        tokens.append(("class:question", f" {message} "))
+
+        return to_formatted_text(tokens)
+
+    def exit_with_result(event):
+        event.app.exit(result=None)
+
+    bindings = KeyBindings()
+
+    @bindings.add(Keys.Any)
+    def any_key(event):
+        exit_with_result(event)
+
+    return Question(
+        PromptSession(
+            get_prompt_tokens, key_bindings=bindings, style=merged_style, **kwargs
+        ).app
+    )

--- a/questionary/prompts/press_any_key_to_continue.py
+++ b/questionary/prompts/press_any_key_to_continue.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Optional
 
 from prompt_toolkit import PromptSession
@@ -14,7 +15,7 @@ from questionary.question import Question
 def press_any_key_to_continue(
     message: Optional[str] = None,
     style: Optional[Style] = None,
-    **kwargs,
+    **kwargs: Any,
 ):
     """Wait until user presses any key to continue.
 
@@ -22,21 +23,21 @@ def press_any_key_to_continue(
         >>> import questionary
         >>> questionary.press_any_key_to_continue().ask()
          Press any key to continue...
-        None
+        ''
 
     Args:
-        message: Question text. Defaults to `"Press any key to continue..."`
+        message: Question text. Defaults to ``"Press any key to continue..."``
 
         style: A custom color and style for the question parts. You can
                configure colors as well as font types for different elements.
 
     Returns:
-        :class:`Question`: Question instance, ready to be prompted (using `.ask()`).
+        :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).
     """
     merged_style = merge_styles([DEFAULT_STYLE, style])
 
     if message is None:
-        message = ("Press any key to continue...",)
+        message = "Press any key to continue..."
 
     def get_prompt_tokens():
         tokens = []

--- a/questionary/prompts/press_any_key_to_continue.py
+++ b/questionary/prompts/press_any_key_to_continue.py
@@ -6,10 +6,9 @@ from prompt_toolkit.formatted_text import to_formatted_text
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.styles import Style
-from prompt_toolkit.styles import merge_styles
 
-from questionary.constants import DEFAULT_STYLE
 from questionary.question import Question
+from questionary.styles import merge_styles_default
 
 
 def press_any_key_to_continue(
@@ -34,7 +33,7 @@ def press_any_key_to_continue(
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).
     """
-    merged_style = merge_styles([DEFAULT_STYLE, style])
+    merged_style = merge_styles_default([style])
 
     if message is None:
         message = "Press any key to continue..."

--- a/tests/prompts/test_press_any_key_to_continue.py
+++ b/tests/prompts/test_press_any_key_to_continue.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from tests.utils import feed_cli_with_input
+
+
+def test_press_any_key_to_continue_default_message():
+    message = None
+    text = "c"
+    result, cli = feed_cli_with_input("press_any_key_to_continue", message, text)
+
+    assert result is None


### PR DESCRIPTION
**What is the problem that this PR addresses?**
* Previously, there was no convenient way of prompting "Press any key to continue...".
* A similar effect could be achieved using the `confirm` prompt, but it would display yes/no, which may confuse the user.
* Built ontop of #270 so that pre-commit can actually run.

**How did you solve it?**
* Implements a "Press any key to continue..." prompt, modeled after the `confirm` prompt.
* We can populate more documentation and stuff if we are happy with this feature.

**Example Use Case**

```
from questionary import press_any_key_to_continue

# Block until the user presses a key
press_any_key_to_continue().ask()  # Prints " Press any key to continue..."
```

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
