### PR TITLE
feat: Add dynamic instruction message for checkbox

### DIFF
--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -105,7 +105,7 @@ def checkbox(
 
         use_emacs_keys: Allow the user to select items from the list using
                         `Ctrl+N` (down) and `Ctrl+P` (up) keys.
-        instruction: A hint on how to navigate the menu.
+        instruction: A message describing how to navigate the menu.
 
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).
@@ -166,7 +166,7 @@ def checkbox(
                     ("class:answer", "done ({} selections)".format(nbr_selected))
                 )
         else:
-            if instruction:
+            if instruction is not None:
                 tokens.append(("class:instruction", instruction))
             else:
                 tokens.append(

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -105,6 +105,7 @@ def checkbox(
 
         use_emacs_keys: Allow the user to select items from the list using
                         `Ctrl+N` (down) and `Ctrl+P` (up) keys.
+        instruction: A hint on how to navigate the menu.
 
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -38,6 +38,7 @@ def checkbox(
     use_arrow_keys: bool = True,
     use_jk_keys: bool = True,
     use_emacs_keys: bool = True,
+    instruction: Optional[str] = None,
     **kwargs: Any,
 ) -> Question:
     """Ask the user to select from a list of items.
@@ -164,15 +165,18 @@ def checkbox(
                     ("class:answer", "done ({} selections)".format(nbr_selected))
                 )
         else:
-            tokens.append(
-                (
-                    "class:instruction",
-                    "(Use arrow keys to move, "
-                    "<space> to select, "
-                    "<a> to toggle, "
-                    "<i> to invert)",
+            if instruction:
+                tokens.append(("class:instruction", instruction))
+            else:
+                tokens.append(
+                    (
+                        "class:instruction",
+                        "(Use arrow keys to move, "
+                        "<space> to select, "
+                        "<a> to toggle, "
+                        "<i> to invert)",
+                    )
                 )
-            )
         return tokens
 
     def get_selected_values() -> List[Any]:

--- a/tests/prompts/test_checkbox.py
+++ b/tests/prompts/test_checkbox.py
@@ -25,6 +25,15 @@ def test_select_first_choice():
     assert result == ["foo"]
 
 
+def test_select_with_instruction():
+    message = "Foo message"
+    kwargs = {"choices": ["foo", "bar", "bazz"], "instruction": "sample instruction"}
+    text = KeyInputs.SPACE + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("checkbox", message, text, **kwargs)
+    assert result == ["foo"]
+
+
 def test_select_first_choice_with_token_title():
     message = "Foo message"
     kwargs = {


### PR DESCRIPTION
**What is the problem that this PR addresses?**
There was a static instruction message for selectbox. Thanks to this PR, we now have a way to dynamically change the instruction message thanks to `instruction` argument.

example;
```python
questionary.checkbox(
   'Select toppings',
   choices=[
       "Cheese",
       "Tomato",
       "Pineapple",
   ],
   instruction="press <enter> to approve"
).ask()
```

...

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
