### PR TITLE
Move new-lines displayed for the `ctrl+c` message to default constant

### DIFF
--- a/questionary/constants.py
+++ b/questionary/constants.py
@@ -28,7 +28,7 @@ INDICATOR_UNSELECTED = "○"
 DEFAULT_QUESTION_PREFIX = "?"
 
 # Message shown when a user aborts a question prompt using CTRL-C
-DEFAULT_KBI_MESSAGE = "Cancelled by user"
+DEFAULT_KBI_MESSAGE = "\nCancelled by user\n"
 
 # Default text shown when the input is invalid
 INVALID_INPUT = "Invalid input"

--- a/questionary/form.py
+++ b/questionary/form.py
@@ -93,9 +93,7 @@ class Form:
         try:
             return self.unsafe_ask(patch_stdout)
         except KeyboardInterrupt:
-            print("")
             print(kbi_msg)
-            print("")
             return {}
 
     async def ask_async(
@@ -115,7 +113,5 @@ class Form:
         try:
             return await self.unsafe_ask_async(patch_stdout)
         except KeyboardInterrupt:
-            print("")
             print(kbi_msg)
-            print("")
             return {}

--- a/questionary/prompt.py
+++ b/questionary/prompt.py
@@ -77,9 +77,7 @@ def prompt(
     try:
         return unsafe_prompt(questions, answers, patch_stdout, true_color, **kwargs)
     except KeyboardInterrupt:
-        print("")
         print(kbi_msg)
-        print("")
         return {}
 
 

--- a/questionary/question.py
+++ b/questionary/question.py
@@ -42,7 +42,7 @@ class Question:
             sys.stdout.flush()
             return await self.unsafe_ask_async(patch_stdout)
         except KeyboardInterrupt:
-            print("\n{}\n".format(kbi_msg))
+            print("{}".format(kbi_msg))
             return None
 
     def ask(
@@ -63,7 +63,7 @@ class Question:
         try:
             return self.unsafe_ask(patch_stdout)
         except KeyboardInterrupt:
-            print("\n{}\n".format(kbi_msg))
+            print("{}".format(kbi_msg))
             return None
 
     def unsafe_ask(self, patch_stdout: bool = False) -> Any:


### PR DESCRIPTION
**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->

This modules, when the user presses CTRL-C, will print a new-line before and after the message "Cancelled by user ". For some applications, these new-lines might not be desirable.

**How did you solve it?**
<!-- A detailed description of your implementation. -->

Removed the printing of new-lines when the KBI message is printed, and instead moved the new-lines to the default message, un-effecting default operation.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
