### PR TITLE
fix: disabled Choice binding shortcut_key

### DIFF
--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -200,7 +200,7 @@ def select(
                     "for movement are disabled. "
                     "This choice is not reachable.".format(c.title)
                 )
-            if isinstance(c, Separator) or c.shortcut_key is None:
+            if isinstance(c, Separator) or c.shortcut_key is None or c.disabled:
                 continue
 
             # noinspection PyShadowingNames


### PR DESCRIPTION
**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->
When defining a `Choice` type option with simultaneously setting the `shortcut_key` attribute to `str` type and setting the 
 `disabled` attribute to be not `None`, there is an unexpected ability that we can interact with this option using keyboard shortcuts. 

example:
```py
import questionary
from questionary import Choice

options = [
    Choice("One", disabled=True),
    Choice("Three", shortcut_key="3", disabled=True),
    Choice("Two"),
    Choice("Four"),
]
questionary.select("Title: ", options, use_shortcuts=True).ask()
```
![2023-11-12-3367](https://github.com/tmbo/questionary/assets/54403862/70d81410-065c-458b-86f5-3eae8525fd0c)

**How did you solve it?**
<!-- A detailed description of your implementation. -->
I cancel the disabled choice binding the key.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
