### PR TITLE
Ignore `Seperator` when calculating length of choices in `select`

### DIFF
--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -132,14 +132,18 @@ def select(
     if choices is None or len(choices) == 0:
         raise ValueError("A list of choices needs to be provided.")
 
-    if use_shortcuts and len(choices) > len(InquirerControl.SHORTCUT_KEYS):
-        raise ValueError(
-            "A list with shortcuts supports a maximum of {} "
-            "choices as this is the maximum number "
-            "of keyboard shortcuts that are available. You"
-            "provided {} choices!"
-            "".format(len(InquirerControl.SHORTCUT_KEYS), len(choices))
+    if use_shortcuts:
+        real_len_of_choices = sum(
+            1 for c in choices if not isinstance(c, Separator)
         )
+        if real_len_of_choices > len(InquirerControl.SHORTCUT_KEYS):
+            raise ValueError(
+                "A list with shortcuts supports a maximum of {} "
+                "choices as this is the maximum number "
+                "of keyboard shortcuts that are available. You "
+                "provided {} choices!"
+                "".format(len(InquirerControl.SHORTCUT_KEYS), real_len_of_choices)
+            )
 
     merged_style = merge_styles_default([style])
 

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -133,9 +133,7 @@ def select(
         raise ValueError("A list of choices needs to be provided.")
 
     if use_shortcuts:
-        real_len_of_choices = sum(
-            1 for c in choices if not isinstance(c, Separator)
-        )
+        real_len_of_choices = sum(1 for c in choices if not isinstance(c, Separator))
         if real_len_of_choices > len(InquirerControl.SHORTCUT_KEYS):
             raise ValueError(
                 "A list with shortcuts supports a maximum of {} "


### PR DESCRIPTION
**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->
Ignore `Seperator` when calculating length of choices in `select` so that we can make full use of the maximum number of keyboard shortcuts.

**How did you solve it?**
<!-- A detailed description of your implementation. -->

From
```py
len(choices)
```
To
```py
sum(1 for c in choices if not isinstance(c, Separator))
```

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
