### PR TITLE
Try to support prompt_toolkit >3.0.37

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -577,13 +577,13 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.36"
+version = "3.0.47"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
-python-versions = ">=3.6.2"
+python-versions = ">=3.7.0"
 files = [
-    {file = "prompt_toolkit-3.0.36-py3-none-any.whl", hash = "sha256:aa64ad242a462c5ff0363a7b9cfe696c20d55d9fc60c11fd8e632d064804d305"},
-    {file = "prompt_toolkit-3.0.36.tar.gz", hash = "sha256:3e163f254bef5a03b146397d7c1963bd3e2812f0964bb9a24e6ec761fd28db63"},
+    {file = "prompt_toolkit-3.0.47-py3-none-any.whl", hash = "sha256:0d7bfa67001d5e39d02c224b663abc33687405033a8c422d0d675a5a13361d10"},
+    {file = "prompt_toolkit-3.0.47.tar.gz", hash = "sha256:1e1b29cb58080b1e69f207c893a1a7bf16d127a5c30c9d17a25a5d77792e5360"},
 ]
 
 [package.dependencies]
@@ -1104,4 +1104,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "89d56b75b6d9ca1303b0561288d900531c89d84142b72a9c0dcbf9dff78da0ae"
+content-hash = "8385e8cdfdc17a456d30af3d04c180715a5297a595567a5d1f2fe261b23f3dcf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-prompt_toolkit = ">=2.0,<=3.0.36"  # once https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1726 is fixed, this can be changed to ">=2.0,<4.0"
+prompt_toolkit = ">=2.0,<4.0"
 
 [tool.poetry.group.docs]
 optional = true

--- a/tests/prompts/test_common.py
+++ b/tests/prompts/test_common.py
@@ -1,8 +1,10 @@
+import asyncio
 from unittest.mock import Mock
 from unittest.mock import call
 
 import pytest
 from prompt_toolkit.document import Document
+from prompt_toolkit.input.defaults import create_pipe_input
 from prompt_toolkit.output import DummyOutput
 from prompt_toolkit.styles import Attrs
 from prompt_toolkit.validation import ValidationError
@@ -13,7 +15,6 @@ from questionary.prompts import common
 from questionary.prompts.common import InquirerControl
 from questionary.prompts.common import build_validator
 from questionary.prompts.common import print_formatted_text
-from tests.utils import execute_with_input_pipe
 from tests.utils import prompt_toolkit_version
 
 
@@ -72,7 +73,7 @@ def test_blank_line_fix():
 
     ic = InquirerControl(["a", "b", "c"])
 
-    def run(inp):
+    async def run(inp):
         inp.send_text("")
         layout = common.create_inquirer_layout(
             ic, get_prompt_tokens, input=inp, output=DummyOutput()
@@ -86,7 +87,15 @@ def test_blank_line_fix():
             == 1000000000000000000000000000001
         )
 
-    execute_with_input_pipe(run)
+    if prompt_toolkit_version < (3, 0, 29):
+        inp = create_pipe_input()
+        try:
+            return asyncio.run(run(inp))
+        finally:
+            inp.close()
+    else:
+        with create_pipe_input() as inp:
+            asyncio.run(run(inp))
 
 
 def test_prompt_highlight_coexist():


### PR DESCRIPTION
Currently one test will fail with latest prompt_toolkit(3.0.43). test_blank_line_fix will throw RuntimeError: no running event loop. By bisecting commit, the culprit is
https://github.com/prompt-toolkit/python-prompt-toolkit/commit/a7759969891c54ea56abfa286524cc301eedaf05. This commit replaces custom `get_event_loop` with `asyncio.get_event_loop`. The former will creator a new loop if `asyncio.get_running_loop` fails while the latter won't. I mimic the changes in the examples to use `asyncio.run` and the test passes. I'm not sure whether more changes are needed.

**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->
Closes: https://github.com/tmbo/questionary/issues/344

**How did you solve it?**
<!-- A detailed description of your implementation. -->
Use `asyncio.run` to make the test pass.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
