### PR TITLE
Change `Choice.shortcut_key` to property with setter

### DIFF
--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -69,8 +69,7 @@ class Choice:
     checked: Optional[bool]
     """Whether the choice is initially selected"""
 
-    shortcut_key: Optional[str]
-    """A shortcut key for the choice"""
+    __shortcut_key: Optional[Union[str, bool]]
 
     description: Optional[str]
     """Choice description"""
@@ -86,6 +85,7 @@ class Choice:
     ) -> None:
         self.disabled = disabled
         self.title = title
+        self.shortcut_key = shortcut_key
         self.checked = checked if checked is not None else False
         self.description = description
 
@@ -95,17 +95,6 @@ class Choice:
             self.value = "".join([token[1] for token in title])
         else:
             self.value = title
-
-        if shortcut_key is not None:
-            if isinstance(shortcut_key, bool):
-                self.auto_shortcut = shortcut_key
-                self.shortcut_key = None
-            else:
-                self.shortcut_key = str(shortcut_key)
-                self.auto_shortcut = False
-        else:
-            self.shortcut_key = None
-            self.auto_shortcut = True
 
     @staticmethod
     def build(c: Union[str, "Choice", Dict[str, Any]]) -> "Choice":
@@ -133,6 +122,29 @@ class Choice:
                 c.get("key"),
                 c.get("description", None),
             )
+
+    @property
+    def shortcut_key(self) -> Optional[Union[str, bool]]:
+        """A shortcut key for the choice"""
+        return self.__shortcut_key
+
+    @shortcut_key.setter
+    def shortcut_key(self, key: Optional[Union[str, bool]]):
+        if key is not None:
+            if isinstance(key, bool):
+                self.auto_shortcut = key
+                self.__shortcut_key = None
+            else:
+                self.__shortcut_key = str(key)
+                self.auto_shortcut = False
+        else:
+            self.__shortcut_key = None
+            self.auto_shortcut = True
+
+    @shortcut_key.deleter
+    def shortcut_key(self):
+        self.__shortcut_key = None
+        self.auto_shortcut = True
 
     def get_shortcut_title(self):
         if self.shortcut_key is None:

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -86,6 +86,7 @@ class Choice:
         self.disabled = disabled
         self.title = title
         self.shortcut_key = shortcut_key
+        # self.auto_shortcut is set by self.shortcut_key.fset
         self.checked = checked if checked is not None else False
         self.description = description
 
@@ -132,25 +133,44 @@ class Choice:
     def shortcut_key(self, key: Optional[Union[str, bool]]):
         if key is not None:
             if isinstance(key, bool):
-                self.auto_shortcut = key
+                self.__auto_shortcut = key
                 self.__shortcut_key = None
             else:
                 self.__shortcut_key = str(key)
-                self.auto_shortcut = False
+                self.__auto_shortcut = False
         else:
             self.__shortcut_key = None
-            self.auto_shortcut = True
+            self.__auto_shortcut = True
 
     @shortcut_key.deleter
     def shortcut_key(self):
         self.__shortcut_key = None
-        self.auto_shortcut = True
+        self.__auto_shortcut = True
 
     def get_shortcut_title(self):
         if self.shortcut_key is None:
             return "-) "
         else:
             return "{}) ".format(self.shortcut_key)
+
+    @property
+    def auto_shortcut(self) -> bool:
+        """Whether to assign a shortcut key to the choice
+
+        Keys are assigned starting with numbers and proceeding
+        through the ASCII alphabet.
+        """
+        return self.__auto_shortcut
+
+    @auto_shortcut.setter
+    def auto_shortcut(self, should_assign: bool):
+        self.__auto_shortcut = should_assign
+        if self.__auto_shortcut:
+            self.__shortcut_key = None
+
+    @auto_shortcut.deleter
+    def auto_shortcut(self):
+        self.__auto_shortcut = False
 
 
 class Separator(Choice):

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -86,7 +86,7 @@ class Choice:
         self.disabled = disabled
         self.title = title
         self.shortcut_key = shortcut_key
-        # self.auto_shortcut is set by self.shortcut_key.fset
+        # self.auto_shortcut is set by the self.shortcut_key setter
         self.checked = checked if checked is not None else False
         self.description = description
 

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from copy import copy
+
 import pytest
 
 from questionary import Choice
@@ -197,6 +199,29 @@ def test_allow_shortcut_key_with_True():
 
     result, cli = feed_cli_with_input("select", message, text, **kwargs)
     assert result == "bazz"
+
+
+def test_auto_shortcut_key_stable_in_loop():
+    message = "Foo message"
+    choices = [
+        Choice("foo"),
+        Choice("bar"),
+    ]
+    kwargs = {
+        "choices": choices,
+        "use_shortcuts": True,
+    }
+    text = "\r"
+
+    result, cli = feed_cli_with_input("select", message, text, **kwargs)
+    assert result == "foo"
+    result_shortcut_keys = [copy(c.shortcut_key) for c in choices]
+    result2, cli = feed_cli_with_input("select", message, text, **kwargs)
+    assert result2 == "foo"
+    result2_shortcut_keys = [copy(c.shortcut_key) for c in choices]
+    assert (
+        result_shortcut_keys == result2_shortcut_keys
+    ), "Shortcut keys changed across two runs of 'select'"
 
 
 def test_select_initial_choice_with_value():


### PR DESCRIPTION
**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->
Ensures that `Choice.auto_shortcut` is set to `False` whenever `Choice.shortcut_key` is set to a `str` value and vice versa

Closes #340

**How did you solve it?**
<!-- A detailed description of your implementation. -->
Implemented the suggested fix in PR #340 to convert `Choices.shortcut_key` to a property with a setter.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
