### PR TITLE
Merge styles with Choice custom styles

### DIFF
--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -457,7 +457,12 @@ class InquirerControl(FormattedTextControl):
                     tokens.append(("class:text", "{}".format(indicator)))
 
                 if isinstance(choice.title, list):
-                    tokens.extend(choice.title)
+                    if selected:
+                        tokens.extend(map(lambda title : (title[0] + " class:selected", title[1])  , choice.title))
+                    elif index == self.pointed_at:
+                        tokens.extend(map(lambda title : (title[0] + " class:highlighted", title[1])  , choice.title))
+                    else:
+                        tokens.extend(choice.title)
                 elif selected:
                     tokens.append(
                         ("class:selected", "{}{}".format(shortcut, choice.title))

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -458,11 +458,15 @@ class InquirerControl(FormattedTextControl):
 
                 if isinstance(choice.title, list):
                     if selected:
-                        tokens.extend(map(lambda title : (title[0] + " class:selected", title[1])  , choice.title))
+                        extra_style = " class:selected"
                     elif index == self.pointed_at:
-                        tokens.extend(map(lambda title : (title[0] + " class:highlighted", title[1])  , choice.title))
+                        extra_style = " class:highlighted"
                     else:
-                        tokens.extend(choice.title)
+                        extra_style = ""
+                    tokens.extend(
+                        (fragment[0] + extra_style, fragment[1])
+                        for fragment in choice.title
+                    )
                 elif selected:
                     tokens.append(
                         ("class:selected", "{}{}".format(shortcut, choice.title))

--- a/tests/prompts/test_common.py
+++ b/tests/prompts/test_common.py
@@ -137,6 +137,44 @@ def test_prompt_highlight_coexist():
     assert ic._get_choice_tokens() == expected_tokens
 
 
+def test_prompt_highlight_selected_with_custom_styles():
+    # formatted-text (list) titles should keep their custom style and also
+    # pick up the highlighted/selected style (see #151)
+    ic = InquirerControl(
+        [
+            Choice(title=[("fg:red", "a")]),
+            Choice(title=[("fg:blue", "b")], checked=True),
+        ]
+    )
+
+    expected_tokens = [
+        ("class:pointer", " » "),
+        ("[SetCursorPosition]", ""),
+        ("class:text", "○ "),
+        ("fg:red class:highlighted", "a"),
+        ("", "\n"),
+        ("class:text", "   "),
+        ("class:selected", "● "),
+        ("fg:blue class:selected", "b"),
+    ]
+    assert ic.pointed_at == 0
+    assert ic._get_choice_tokens() == expected_tokens
+
+    ic.select_next()
+    expected_tokens = [
+        ("class:text", "   "),
+        ("class:text", "○ "),
+        ("fg:red", "a"),
+        ("", "\n"),
+        ("class:pointer", " » "),
+        ("[SetCursorPosition]", ""),
+        ("class:selected", "● "),
+        ("fg:blue class:selected", "b"),
+    ]
+    assert ic.pointed_at == 1
+    assert ic._get_choice_tokens() == expected_tokens
+
+
 def test_prompt_show_answer_with_shortcuts():
     ic = InquirerControl(
         ["a", Choice("b", shortcut_key=False), "c"],


### PR DESCRIPTION
Allow selected and highlighted styles to work with Choice custom styles.

**What is the problem that this PR addresses?**
I needed the hightlighting functionality with custom styles no my Choices.

Closes https://github.com/tmbo/questionary/issues/151
...

**How did you solve it?**
I found that when the `title` param on Choice is a list it just `extend` the styles not checking if `selected` or `hightlighted` exists

...

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [ ] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
