### PR TITLE
Update deprecated autoflake hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/humitos/mirrors-autoflake
-    rev: v1.1
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v2.3.1
     hooks:
       - id: autoflake
         args: ["-i", "--remove-all-unused-imports"]


### PR DESCRIPTION
As stated in https://github.com/humitos/mirrors-autoflake/blob/master/README.md, DO NOT USE THIS REPOSITORY. There is an official version now at https://github.com/PyCQA/autoflake/blob/master/.pre-commit-hooks.yaml.

There are some errors when using this deprecated hook under Python 3.12, such as

```
Traceback (most recent call last):
  File "/home/fanta/.cache/pre-commit/repoo2mq6vmn/py_env-python3.12/bin/autoflake", line 5, in <module>
    from autoflake import main
  File "/home/fanta/.cache/pre-commit/repoo2mq6vmn/py_env-python3.12/lib/python3.12/site-packages/autoflake.py", line 32, in <module>
    import distutils.sysconfig
ModuleNotFoundError: No module named 'distutils'
```

**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->

...

**How did you solve it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
