### PR TITLE
Update flake8 pre-commit hook to 7.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
           - "--profile=black"
 
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.1.0
     hooks:
       - id: flake8
         args: ["--max-line-length", "120", "--max-doc-length", "140"]


### PR DESCRIPTION
This patch resolves lint failure when using Python 3.12.
```
questionary/prompts/common.py:282:24: E713 test for membership should be 'not in'
questionary/prompts/common.py:300:45: E713 test for membership should be 'not in'
```
Flake8 adds Python 3.12 support in 6.1.0.

**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->

...

**How did you solve it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
