### PR TITLE
Remove setup.cfg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,12 @@ line-length = 88
 target-version = ["py38", "py39", "py310", "py311", "py312"]
 exclude = "((.eggs | .git | .pytype | .pytest_cache | build | dist))"
 
+[tool.mypy]
+ignore_missing_imports = true
+show_error_codes = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
 [tool.poetry]
 name = "questionary"
 version = "2.0.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,0 @@
-[metadata]
-description-file = README.md
-license_file = LICENSE
-[mypy]
-ignore_missing_imports = True
-show_error_codes = True
-warn_redundant_casts = True
-warn_unused_ignores = True


### PR DESCRIPTION
**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->
Since questionary uses poetry instead of setuptools, it's better not keep setup.cfg. Mypy can be configured using pyproject.toml.
**How did you solve it?**
<!-- A detailed description of your implementation. -->

https://mypy.readthedocs.io/en/stable/config_file.html

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
