### PR TITLE
allow Path object to be passed as default

### DIFF
--- a/questionary/prompts/path.py
+++ b/questionary/prompts/path.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import Iterable
@@ -115,7 +116,7 @@ class GreatUXPathCompleter(PathCompleter):
 
 def path(
     message: str,
-    default: str = "",
+    default: Path | str = "",
     qmark: str = DEFAULT_QUESTION_PREFIX,
     validate: Any = None,
     completer: Optional[Completer] = None,
@@ -238,6 +239,6 @@ def path(
         key_bindings=bindings,
         **kwargs,
     )
-    p.default_buffer.reset(Document(default))
+    p.default_buffer.reset(Document(str(default)))
 
     return Question(p.app)


### PR DESCRIPTION
**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
More oftan than not, when we prompt the user for a path, we later construct a builtin `Path` object from the received string. Following this notion, it is only logical that such object can also be passed as `default` parameter to the `questionary.path()` function.




**How did you solve it?**
<!-- A detailed description of your implementation. -->
We expand the type of `default` parameter to `Path | str` while also keeping its default value to be an empty string. Then we change the reference to this parameter on line 242 and we cast it to string using `str(default)`. If `default` is of type `Path`, then we recieve the corresponding path as a string, if its type is `str` then nothing happens.


**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
