### PR TITLE
add a flag to retain options on the screen even after the user has se…

### DIFF
--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -41,6 +41,7 @@ def checkbox(
     use_search_filter: Union[str, bool, None] = False,
     instruction: Optional[str] = None,
     show_description: bool = True,
+    keep_options_displayed: bool = True,
     **kwargs: Any,
 ) -> Question:
     """Ask the user to select from a list of items.
@@ -222,7 +223,9 @@ def checkbox(
 
         return valid
 
-    layout = common.create_inquirer_layout(ic, get_prompt_tokens, **kwargs)
+    layout = common.create_inquirer_layout(
+        ic, get_prompt_tokens, keep_options_displayed=keep_options_displayed, **kwargs
+    )
 
     bindings = KeyBindings()
 

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -601,6 +601,7 @@ def _fix_unecessary_blank_lines(ps: PromptSession) -> None:
 def create_inquirer_layout(
     ic: InquirerControl,
     get_prompt_tokens: Callable[[], List[Tuple[str, str]]],
+    keep_options_displayed: bool = True,  # New flag
     **kwargs: Any,
 ) -> Layout:
     """Create a layout combining question and inquirer selection."""
@@ -618,11 +619,14 @@ def create_inquirer_layout(
         bottom_toolbar=lambda: ic.error_message, **kwargs
     )
 
+    # Modify the filter for options based on `keep_options_displayed`
+    options_filter = ~IsDone() if not keep_options_displayed else Always()
+
     return Layout(
         HSplit(
             [
                 ps.layout.container,
-                ConditionalContainer(Window(ic), filter=~IsDone()),
+                ConditionalContainer(Window(ic), filter=options_filter),  # Change here
                 ConditionalContainer(
                     Window(
                         height=LayoutDimension.exact(2),

--- a/questionary/prompts/rawselect.py
+++ b/questionary/prompts/rawselect.py
@@ -20,6 +20,7 @@ def rawselect(
     qmark: str = DEFAULT_QUESTION_PREFIX,
     pointer: Optional[str] = DEFAULT_SELECTED_POINTER,
     style: Optional[Style] = None,
+    keep_options_displayed: bool = True,
     **kwargs: Any,
 ) -> Question:
     """Ask the user to select one item from a list of choices using shortcuts.
@@ -74,6 +75,7 @@ def rawselect(
         pointer,
         style,
         use_shortcuts=True,
-        use_arrow_keys=False,
+        use_arrow_keys=True,
+        keep_options_displayed=keep_options_displayed,
         **kwargs,
     )

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -39,6 +39,7 @@ def select(
     show_selected: bool = False,
     show_description: bool = True,
     instruction: Optional[str] = None,
+    keep_options_displayed: bool = True,
     **kwargs: Any,
 ) -> Question:
     """A list of items to select **one** option from.
@@ -202,7 +203,9 @@ def select(
 
         return tokens
 
-    layout = common.create_inquirer_layout(ic, get_prompt_tokens, **kwargs)
+    layout = common.create_inquirer_layout(
+        ic, get_prompt_tokens, keep_options_displayed=keep_options_displayed, **kwargs
+    )
 
     bindings = KeyBindings()
 

--- a/questionary/question.py
+++ b/questionary/question.py
@@ -24,7 +24,10 @@ class Question:
         self.default = None
 
     async def ask_async(
-        self, patch_stdout: bool = False, kbi_msg: str = DEFAULT_KBI_MESSAGE
+        self,
+        patch_stdout: bool = False,
+        kbi_msg: str = DEFAULT_KBI_MESSAGE,
+        **kwargs: Any,
     ) -> Any:
         """Ask the question using asyncio and return user response.
 
@@ -40,13 +43,16 @@ class Question:
 
         try:
             sys.stdout.flush()
-            return await self.unsafe_ask_async(patch_stdout)
+            return await self.unsafe_ask_async(patch_stdout, **kwargs)
         except KeyboardInterrupt:
             print("{}".format(kbi_msg))
             return None
 
     def ask(
-        self, patch_stdout: bool = False, kbi_msg: str = DEFAULT_KBI_MESSAGE
+        self,
+        patch_stdout: bool = False,
+        kbi_msg: str = DEFAULT_KBI_MESSAGE,
+        **kwargs: Any,
     ) -> Any:
         """Ask the question synchronously and return user response.
 
@@ -61,12 +67,12 @@ class Question:
         """
 
         try:
-            return self.unsafe_ask(patch_stdout)
+            return self.unsafe_ask(patch_stdout, **kwargs)
         except KeyboardInterrupt:
             print("{}".format(kbi_msg))
             return None
 
-    def unsafe_ask(self, patch_stdout: bool = False) -> Any:
+    def unsafe_ask(self, patch_stdout: bool = False, **kwargs: Any) -> Any:
         """Ask the question synchronously and return user response.
 
         Does not catch keyboard interrupts.
@@ -84,9 +90,9 @@ class Question:
 
         if patch_stdout:
             with prompt_toolkit.patch_stdout.patch_stdout():
-                return self.application.run()
+                return self.application.run(**kwargs)
         else:
-            return self.application.run()
+            return self.application.run(**kwargs)
 
     def skip_if(self, condition: bool, default: Any = None) -> "Question":
         """Skip the question if flag is set and return the default instead.
@@ -103,7 +109,7 @@ class Question:
         self.default = default
         return self
 
-    async def unsafe_ask_async(self, patch_stdout: bool = False) -> Any:
+    async def unsafe_ask_async(self, patch_stdout: bool = False, **kwargs: Any) -> Any:
         """Ask the question using asyncio and return user response.
 
         Does not catch keyboard interrupts.
@@ -124,9 +130,9 @@ class Question:
 
         if patch_stdout:
             with prompt_toolkit.patch_stdout.patch_stdout():
-                r = self.application.run_async()
+                r = self.application.run_async(**kwargs)
         else:
-            r = self.application.run_async()
+            r = self.application.run_async(**kwargs)
 
         if utils.is_prompt_toolkit_3():
             return await r


### PR DESCRIPTION
**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->
Closes #313

The issue relates to the default behavior of certain prompts in the questionary library. Currently, when a user selects an option in prompts like select, rawselect, or checkbox, the displayed options disappear immediately after selection. This behavior can make it difficult for users to review the available or selected options.

**How did you solve it?**
<!-- A detailed description of your implementation. -->

I added a new feature in the form of an optional flag keep_options_displayed to the following prompts:

select
rawselect
checkbox
Feature added:
If keep_options_displayed=True, the options remain displayed after the selection is made.
If keep_options_displayed=False (default behavior), the options disappear immediately after the selection.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [ ] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
