### PR TITLE
Add dite/time input with default value with a defined range

### DIFF
--- a/questionary/__init__.py
+++ b/questionary/__init__.py
@@ -23,6 +23,7 @@ from questionary.prompts.press_any_key_to_continue import press_any_key_to_conti
 from questionary.prompts.rawselect import rawselect
 from questionary.prompts.select import select
 from questionary.prompts.text import text
+from questionary.prompts.date import date
 from questionary.question import Question
 
 __version__ = questionary.version.__version__
@@ -39,6 +40,7 @@ __all__ = [
     "rawselect",
     "select",
     "text",
+    "date",
     # utility methods
     "print",
     "form",

--- a/questionary/prompts/__init__.py
+++ b/questionary/prompts/__init__.py
@@ -7,11 +7,13 @@ from questionary.prompts import press_any_key_to_continue
 from questionary.prompts import rawselect
 from questionary.prompts import select
 from questionary.prompts import text
+from questionary.prompts import date
 
 AVAILABLE_PROMPTS = {
     "autocomplete": autocomplete.autocomplete,
     "confirm": confirm.confirm,
     "text": text.text,
+    "date": date.date,
     "select": select.select,
     "rawselect": rawselect.rawselect,
     "password": password.password,

--- a/questionary/prompts/date.py
+++ b/questionary/prompts/date.py
@@ -1,0 +1,98 @@
+from typing import Any, Optional
+from datetime import datetime
+
+from questionary import Style
+from questionary.constants import DEFAULT_QUESTION_PREFIX
+from questionary.prompts import text
+from questionary.question import Question
+
+
+def date(
+    message: str,
+    default: Optional[str] = None,
+    validate: Any = None,
+    qmark: str = DEFAULT_QUESTION_PREFIX,
+    style: Optional[Style] = None,
+    format: str = "%Y-%m-%d",
+    min_date: Optional[str] = None,
+    max_date: Optional[str] = None,
+    **kwargs: Any,
+) -> Question:
+    """
+    Prompt the user to enter a date.
+
+    This question type can be used to prompt the user for a date input,
+    with optional validation, formatting, and range restrictions.
+
+    Example:
+        >>> import questionary
+        >>> questionary.date("Enter your birthdate (YYYY-MM-DD):").ask()
+        ? Enter your birthdate (YYYY-MM-DD): 1990-01-01
+        '1990-01-01'
+
+    Args:
+        message: Question text.
+
+        default: Default date value in the given format. Defaults to None.
+
+        validate: Custom validation function for the date input.
+                  This can either be a function accepting the input and
+                  returning a boolean, or a class reference to a
+                  subclass of the prompt toolkit Validator class.
+
+        qmark: Question prefix displayed in front of the question.
+               By default this is a ``?``.
+
+        style: A custom color and style for the question parts. You can
+               configure colors as well as font types for different elements.
+
+        format: The expected date format (e.g., "%Y-%m-%d"). Defaults to "%Y-%m-%d".
+
+        min_date: The minimum allowed date in the given format. Defaults to None.
+
+        max_date: The maximum allowed date in the given format. Defaults to None.
+
+        kwargs: Additional arguments, they will be passed to prompt toolkit.
+
+    Returns:
+        :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).
+    """
+
+    def date_validator(input_date: str) -> bool:
+        """Validate the entered date based on format and range."""
+        try:
+            parsed_date = datetime.strptime(input_date, format)
+
+            # Validate minimum date
+            if min_date:
+                min_date_obj = datetime.strptime(min_date, format)
+                if parsed_date < min_date_obj:
+                    raise ValueError(
+                        f"Date must not be earlier than {min_date}."
+                    )
+
+            # Validate maximum date
+            if max_date:
+                max_date_obj = datetime.strptime(max_date, format)
+                if parsed_date > max_date_obj:
+                    raise ValueError(
+                        f"Date must not be later than {max_date}."
+                    )
+
+            return True
+        except ValueError as e:
+            raise ValueError(str(e))
+
+    # Use the provided validator or the built-in date_validator
+    final_validator = validate or date_validator
+
+    return text.text(
+        message=message,
+        default=default,
+        validate=final_validator,
+        qmark=qmark,
+        style=style,
+        **kwargs,
+    )
+
+

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -1,0 +1,25 @@
+import questionary
+
+questionary.date(
+    "Which date do you want?",
+    format="%Y-%m-%d",
+).ask()
+questionary.text("What's your first name").ask()
+questionary.password("What's your secret?").ask()
+questionary.confirm("Are you amazed?").ask()
+
+questionary.select(
+    "What do you want to do?",
+    choices=["Order a pizza", "Make a reservation", "Ask for opening hours"],
+).ask()
+
+questionary.rawselect(
+    "What do you want to do?",
+    choices=["Order a pizza", "Make a reservation", "Ask for opening hours"],
+).ask()
+
+questionary.checkbox(
+    "Select toppings", choices=["foo", "bar", "bazz"]
+).ask()
+
+questionary.path("Path to the projects version file").ask()

--- a/tests/prompts/test_date.py
+++ b/tests/prompts/test_date.py
@@ -1,0 +1,17 @@
+import pytest
+from prompt_toolkit.input.defaults import create_pipe_input
+from prompt_toolkit.output import DummyOutput
+from questionary.prompts.date import date
+
+
+def test_date_prompt_with_default():
+    """Test de saisie avec une valeur par défaut."""
+    with create_pipe_input() as pipe_input:
+        pipe_input.send_text("\n")  # L'utilisateur appuie simplement sur Entrée
+        result = date(
+            "Enter a date (default is 2023-01-01):",
+            default="2023-01-01",  # Définit une valeur par défaut valide
+            input=pipe_input,
+            output=DummyOutput()
+        ).ask()
+        assert result == "2023-01-01"


### PR DESCRIPTION
**What is the problem that this PR addresses?**

This PR addresses the need to verify the handling of default values and the validation of date input prompts. Specifically, it ensures that when the user presses "Enter" without providing a date, the default date value is correctly returned. Additionally, this PR introduces functionality to validate if the input date falls within a defined range, with a minimum and maximum date that can be specified.

Closes #121 (assuming this is the issue related to the functionality being tested)

**How did you solve it?**

I implemented a unit test for the date input prompt. The test simulates a scenario where the user presses "Enter" without providing a date, which should return the default value specified (in this case, "2023-01-01"). The test uses create_pipe_input to simulate the user input and DummyOutput to handle output, verifying that the expected default value is returned correctly.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [ x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [ x] I will check that all automated PR checks pass before the PR gets reviewed.
