### PR TITLE
Fix dynamically-generated select choices

### DIFF
--- a/examples/dependent_selects.py
+++ b/examples/dependent_selects.py
@@ -1,0 +1,27 @@
+from pprint import pprint
+
+from questionary import prompt
+
+OPTIONS = {"key1": ["k1v1", "k1v2"], "key2": ["k2v1", "k2v2"]}
+
+
+def ask_dictstyle(**kwargs):
+    questions = [
+        {
+            "type": "select",
+            "name": "key",
+            "message": "Choose a key",
+            "choices": OPTIONS.keys(),
+        },
+        {
+            "type": "select",
+            "name": "value",
+            "message": "Choose a value",
+            "choices": lambda x: OPTIONS[x["key"]],
+        },
+    ]
+    return prompt(questions, **kwargs)
+
+
+if __name__ == "__main__":
+    pprint(ask_dictstyle())

--- a/questionary/prompt.py
+++ b/questionary/prompt.py
@@ -192,7 +192,7 @@ def unsafe_prompt(
         if choices is not None and callable(choices):
             calculated_choices = choices(answers)
             question_config["choices"] = calculated_choices
-            kwargs["choices"] = calculated_choices
+            _kwargs["choices"] = calculated_choices
 
         if _filter:
             # at least a little sanity check!

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -126,3 +126,16 @@ def test_advanced_workflow_example():
         "next_question": "questionary",
         "second_question": "Hello World",
     }
+
+
+def test_dependent_selects_example():
+    from examples.dependent_selects import ask_dictstyle
+
+    text = KeyInputs.DOWN + KeyInputs.ENTER + KeyInputs.DOWN + KeyInputs.ENTER
+
+    result_dict = ask_with_patched_input(ask_dictstyle, text)
+
+    assert result_dict == {
+        "key": "key2",
+        "value": "k2v2",
+    }


### PR DESCRIPTION
**What is the problem that this PR addresses?**

Dynamically-generated select choices were broken.

Example:

```python
import questionary
OPTIONS = {
    "key1": ["k1v1", "k1v2"], 
    "key2": ["k2v1", "k2v2"]
}

questions = [
    {
        'type': 'select',
        'name': 'key',
        'message': "Choose a key",
        'choices': OPTIONS.keys(),
    },
    {
        'type': 'select',
        'name': 'value',
        'message': 'Choose a value',
        'choices': lambda x: OPTIONS[x['key']],
    }
]
questionary.prompt(questions)
```

Results in the following error:

```
? Choose a key key1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../venv/lib/python3.10/site-packages/questionary/prompt.py", line 78, in prompt
    return unsafe_prompt(questions, answers, patch_stdout, true_color, **kwargs)
  File ".../venv/lib/python3.10/site-packages/questionary/prompt.py", line 219, in unsafe_prompt
    question = create_question_func(**_kwargs)
  File ".../venv/lib/python3.10/site-packages/questionary/prompts/select.py", line 149, in select
    if choices is None or len(choices) == 0:
TypeError: object of type 'function' has no len()
>>>
```

**How did you solve it?**

Modify the correct object.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
