### PR TITLE
Use PromptSession.layout.find_all_windows() helper for compatibility w/ prompt-toolkit>=3.0.52

### DIFF
--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -18,6 +18,7 @@ from prompt_toolkit.layout import FormattedTextControl
 from prompt_toolkit.layout import HSplit
 from prompt_toolkit.layout import Layout
 from prompt_toolkit.layout import Window
+from prompt_toolkit.layout.controls import BufferControl
 from prompt_toolkit.layout.dimension import LayoutDimension
 from prompt_toolkit.styles import Style
 from prompt_toolkit.validation import ValidationError
@@ -585,13 +586,13 @@ def _fix_unecessary_blank_lines(ps: PromptSession) -> None:
     This assumes the layout of the default session doesn't change, if it
     does, this needs an update."""
 
-    default_container = ps.layout.container
-
-    default_buffer_window = (
-        default_container.get_children()[0].content.get_children()[1].content  # type: ignore[attr-defined]
+    default_buffer_window: Window = next(
+        win
+        for win in ps.layout.find_all_windows()
+        if isinstance(win.content, BufferControl)
+        and win.content.buffer.name == "DEFAULT_BUFFER"
     )
 
-    assert isinstance(default_buffer_window, Window)
     # this forces the main window to stay as small as possible, avoiding
     # empty lines in selections
     default_buffer_window.dont_extend_height = Always()


### PR DESCRIPTION

**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->

Fixes https://github.com/tmbo/questionary/issues/454

**How did you solve it?**
<!-- A detailed description of your implementation. -->

By retrieving the default Prompt Toolkit `Window` instance in a more idiomatic way from a `PromptSession`
instance than using a fixed path through the latter’s `.layout.container` tree structure – which changed w/ release `3.0.52` of Prompt Toolkit, causing the exception described in the linked issue.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
