### PR TITLE
Added support for formatted text in the `select` message

### DIFF
--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -8,6 +8,7 @@ from typing import Sequence
 from typing import Union
 
 from prompt_toolkit.application import Application
+from prompt_toolkit.formatted_text import FormattedText as PTFormattedText
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.styles import Style
@@ -24,7 +25,7 @@ from questionary.styles import merge_styles_default
 
 
 def select(
-    message: str,
+    message: Union[str, Dict[str, Any]],
     choices: Sequence[Union[str, Choice, Dict[str, Any]]],
     default: Optional[Union[str, Choice, Dict[str, Any]]] = None,
     qmark: str = DEFAULT_QUESTION_PREFIX,
@@ -176,7 +177,13 @@ def select(
 
     def get_prompt_tokens():
         # noinspection PyListCreation
-        tokens = [("class:qmark", qmark), ("class:question", " {} ".format(message))]
+        tokens = [("class:qmark", qmark)]
+        if isinstance(message, (list, PTFormattedText)):
+            tokens += message
+        elif hasattr(message, "__pt_formatted_text__"):
+            tokens += list(message.__pt_formatted_text__())
+        else:
+            tokens.append(("class:question", " {} ".format(message)))
 
         if ic.is_answered:
             if isinstance(ic.get_pointed_at().title, list):


### PR DESCRIPTION
**What is the problem that this PR addresses?**  
Currently, the `message` parameter of `questionary.select()` only accepts plain strings and does not support formatted text (e.g., ANSI or Rich styles).  
This makes it impossible to style the prompt title, even though option titles (`choices`) already support formatting via `FormattedText`.

Closes #449  
Related to #107

**How did you solve it?**  
I extended the logic in `select()` so that the `message` parameter now accepts `FormattedText` (including objects with `__pt_formatted_text__` or lists of style/text tuples).  
If a formatted message is provided, it is rendered with all styles and colors preserved, just like for option titles.  
This was tested with both manual ANSI codes and Rich → PromptToolkit conversions to confirm correct rendering.

**Checklist**  
- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).  
- [x] I have checked that all automated PR checks pass before requesting review.
