### PR TITLE
Fix `Choice.disabled` annotation to include `str` or `bool`

### DIFF
--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -50,8 +50,8 @@ class Choice:
                is `None` or unset, then the value of `title` is used.
 
         disabled: If set, the choice can not be selected by the user. The
-                  provided text is used to explain, why the selection is
-                  disabled.
+                  provided text is used to explain why the selection is
+                  disabled or, if a boolean, no explanation is provided.
 
         checked: Preselect this choice when displaying the options.
 


### PR DESCRIPTION
**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->

`Choice.disabled` is annotated as an optional `str` but can also be a `bool`:

https://github.com/tmbo/questionary/blob/dc46610910409c18f53aabbbec111221fccf8a6a/questionary/prompts/common.py#L434-L438

Partially related to https://github.com/tmbo/questionary/issues/251#issuecomment-1240675154

**How did you solve it?**
<!-- A detailed description of your implementation. -->

This PR changes the type of `Choice.disabled` and related annotations to `Optional[Union[str, bool]]`.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [X] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
