### PR TITLE
docs/fix: clarify shortcut key must be lowercase a–z or digit 0–9

### DIFF
--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -55,7 +55,8 @@ class Choice:
 
         checked: Preselect this choice when displaying the options.
 
-        shortcut_key: Key shortcut used to select this item.
+        shortcut_key: Key shortcut used to select this item. Must be a single
+            lowercase letter (a-z) or digit (0-9).
 
         description: Optional description of the item that can be displayed.
     """
@@ -129,7 +130,9 @@ class Choice:
 
     @property
     def shortcut_key(self) -> Optional[Union[str, bool]]:
-        """A shortcut key for the choice"""
+        """Shortcut key for this choice. Must be a single lowercase letter
+        (a-z) or digit (0-9).
+        """
         return self.__shortcut_key
 
     @shortcut_key.setter

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -344,11 +344,11 @@ class InquirerControl(FormattedTextControl):
                     available_shortcuts.remove(c.shortcut_key)
                 else:
                     raise ValueError(
-                        "Invalid shortcut '{}'"
-                        "for choice '{}'. Shortcuts "
-                        "should be single characters or numbers. "
-                        "Make sure that all your shortcuts are "
-                        "unique.".format(c.shortcut_key, c.title)
+                        "Invalid shortcut '{}' for choice '{}'. "
+                        "Shortcuts must be a single lowercase letter (a-z) or "
+                        "digit (0-9), and must be unique.".format(
+                            c.shortcut_key, c.title
+                        )
                     )
 
         shortcut_idx = 0


### PR DESCRIPTION
Questionary is an awesome work!!
I've been using it comfortably alongside [Commitizen](https://github.com/commitizen-tools/commitizen) and followed the same patterns when building CLI flows.

**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->

One small pain point is the shortcut key story: when `use_shortcuts` is on (e.g. `select`, `rawselect`), choices can take a dict `key` (or `Choice(..., shortcut_key=...)`), but the docs and the thrown error didn’t spell out the real rule clearly.

The allowed set is already defined in code as `InquirerControl.SHORTCUT_KEYS`—only **single digits 0–9** and **single lowercase letters a–z**. The previous error text said shortcuts “should be single characters or numbers,” which is easy to read as “any single character,” so users can hit a confusing `ValueError` (e.g. using an uppercase letter) without knowing why.

...

**How did you solve it?**
<!-- A detailed description of your implementation. -->

- **Docstrings**: Updated `Choice`’s `shortcut_key` parameter, and the `shortcut_key` property so they state explicitly that values must be a single lowercase letter (a–z) or digit (0–9), matching `SHORTCUT_KEYS`.
- **Error message**: Replaced the vague wording in `_assign_shortcut_keys()` with a clear message and fixed the missing space between `"Invalid shortcut '…'"` and `"for choice …"`.

...

**Example (invalid key — uppercase `X`):**
```python
import questionary
questionary.select(
    "Pick one",
    use_shortcuts=True,
    choices=[
        {"name": "Apple", "key": "a"},
        {"name": "Banana", "key": "b"},
        {"name": "Cherry", "key": "X"},
    ],
).ask()
```

Resulting error text:

```
ValueError: Invalid shortcut 'X' for choice 'Cherry'.
Shortcuts must be a single lowercase letter (a-z) or digit (0-9), and must be unique.
```

Original error text:

```
ValueError: Invalid shortcut 'X'for choice 'Cherry'.
Shortcuts should be single characters or numbers. Make sure that all your shortcuts are unique.
```



**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [X] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
