### PR TITLE
feat(path): expose min_input_len for path autocompletion

### DIFF
--- a/questionary/prompts/path.py
+++ b/questionary/prompts/path.py
@@ -124,8 +124,8 @@ def path(
     only_directories: bool = False,
     get_paths: Optional[Callable[[], List[str]]] = None,
     file_filter: Optional[Callable[[str], bool]] = None,
-    min_input_len: int = 0,
     complete_style: CompleteStyle = CompleteStyle.MULTI_COLUMN,
+    min_input_len: int = 0,
     **kwargs: Any,
 ) -> Question:
     """A text input for a file or directory path with autocompletion enabled.

--- a/questionary/prompts/path.py
+++ b/questionary/prompts/path.py
@@ -124,6 +124,7 @@ def path(
     only_directories: bool = False,
     get_paths: Optional[Callable[[], List[str]]] = None,
     file_filter: Optional[Callable[[str], bool]] = None,
+    min_input_len: int = 0,
     complete_style: CompleteStyle = CompleteStyle.MULTI_COLUMN,
     **kwargs: Any,
 ) -> Question:
@@ -184,6 +185,10 @@ def path(
                      filtering suggestions you also want to validate the result, use
                      ``validate`` in combination with the ``file_filter``.
 
+        min_input_len: Don't show autocompletions until the input string is at
+                       least this long. Defaults to 0. This option does not do
+                       anything if a custom ``completer`` is passed.
+
     Returns:
         :class:`Question`: Question instance, ready to be prompted (using ``.ask()``).
     """  # noqa: W505, E501
@@ -198,6 +203,7 @@ def path(
         get_paths=get_paths,
         only_directories=only_directories,
         file_filter=file_filter,
+        min_input_len=min_input_len,
         expanduser=True,
     )
 

--- a/tests/prompts/test_path.py
+++ b/tests/prompts/test_path.py
@@ -129,6 +129,37 @@ def test_get_paths_validation(path_completion_tree):
     assert "'get_paths' must return only existing directories" in str(excinfo)
 
 
+def _resolve_completer(buffer_completer):
+    get_completer = getattr(buffer_completer, "get_completer", None)
+    if get_completer is None:
+        return buffer_completer
+    return get_completer()
+
+
+@pytest.mark.skipif(
+    prompt_toolkit.__version__.startswith("2"), reason="requires prompt toolkit >= 3.0"
+)
+def test_min_input_len_forwarded_to_default_completer():
+    """``min_input_len`` is passed through to the default completer."""
+    from questionary.prompts.path import path as path_prompt
+
+    question = path_prompt("Pick your path", min_input_len=4)
+    completer = _resolve_completer(question.application.current_buffer.completer)
+    assert completer.min_input_len == 4
+
+
+@pytest.mark.skipif(
+    prompt_toolkit.__version__.startswith("2"), reason="requires prompt toolkit >= 3.0"
+)
+def test_min_input_len_default_is_zero():
+    """Default behaviour is unchanged: ``min_input_len`` is 0."""
+    from questionary.prompts.path import path as path_prompt
+
+    question = path_prompt("Pick your path")
+    completer = _resolve_completer(question.application.current_buffer.completer)
+    assert completer.min_input_len == 0
+
+
 @pytest.mark.skipif(
     prompt_toolkit.__version__.startswith("2"), reason="requires prompt toolkit >= 3.0"
 )

--- a/tests/prompts/test_path.py
+++ b/tests/prompts/test_path.py
@@ -4,6 +4,7 @@ import pytest
 from prompt_toolkit.completion import Completer
 from prompt_toolkit.completion import Completion
 
+from questionary.prompts.path import path as path_prompt
 from tests.utils import KeyInputs
 from tests.utils import feed_cli_with_input
 
@@ -141,8 +142,6 @@ def _resolve_completer(buffer_completer):
 )
 def test_min_input_len_forwarded_to_default_completer():
     """``min_input_len`` is passed through to the default completer."""
-    from questionary.prompts.path import path as path_prompt
-
     question = path_prompt("Pick your path", min_input_len=4)
     completer = _resolve_completer(question.application.current_buffer.completer)
     assert completer.min_input_len == 4
@@ -153,8 +152,6 @@ def test_min_input_len_forwarded_to_default_completer():
 )
 def test_min_input_len_default_is_zero():
     """Default behaviour is unchanged: ``min_input_len`` is 0."""
-    from questionary.prompts.path import path as path_prompt
-
     question = path_prompt("Pick your path")
     completer = _resolve_completer(question.application.current_buffer.completer)
     assert completer.min_input_len == 0

--- a/tests/prompts/test_path.py
+++ b/tests/prompts/test_path.py
@@ -3,9 +3,11 @@ import prompt_toolkit
 import pytest
 from prompt_toolkit.completion import Completer
 from prompt_toolkit.completion import Completion
+from prompt_toolkit.output import DummyOutput
 
 from questionary.prompts.path import path as path_prompt
 from tests.utils import KeyInputs
+from tests.utils import execute_with_input_pipe
 from tests.utils import feed_cli_with_input
 
 
@@ -142,9 +144,15 @@ def _resolve_completer(buffer_completer):
 )
 def test_min_input_len_forwarded_to_default_completer():
     """``min_input_len`` is passed through to the default completer."""
-    question = path_prompt("Pick your path", min_input_len=4)
-    completer = _resolve_completer(question.application.current_buffer.completer)
-    assert completer.min_input_len == 4
+
+    def run(inp):
+        question = path_prompt(
+            "Pick your path", min_input_len=4, input=inp, output=DummyOutput()
+        )
+        completer = _resolve_completer(question.application.current_buffer.completer)
+        assert completer.min_input_len == 4
+
+    execute_with_input_pipe(run)
 
 
 @pytest.mark.skipif(
@@ -152,9 +160,13 @@ def test_min_input_len_forwarded_to_default_completer():
 )
 def test_min_input_len_default_is_zero():
     """Default behaviour is unchanged: ``min_input_len`` is 0."""
-    question = path_prompt("Pick your path")
-    completer = _resolve_completer(question.application.current_buffer.completer)
-    assert completer.min_input_len == 0
+
+    def run(inp):
+        question = path_prompt("Pick your path", input=inp, output=DummyOutput())
+        completer = _resolve_completer(question.application.current_buffer.completer)
+        assert completer.min_input_len == 0
+
+    execute_with_input_pipe(run)
 
 
 @pytest.mark.skipif(

--- a/tests/prompts/test_path.py
+++ b/tests/prompts/test_path.py
@@ -143,8 +143,6 @@ def _resolve_completer(buffer_completer):
     prompt_toolkit.__version__.startswith("2"), reason="requires prompt toolkit >= 3.0"
 )
 def test_min_input_len_forwarded_to_default_completer():
-    """``min_input_len`` is passed through to the default completer."""
-
     def run(inp):
         question = path_prompt(
             "Pick your path", min_input_len=4, input=inp, output=DummyOutput()
@@ -159,8 +157,6 @@ def test_min_input_len_forwarded_to_default_completer():
     prompt_toolkit.__version__.startswith("2"), reason="requires prompt toolkit >= 3.0"
 )
 def test_min_input_len_default_is_zero():
-    """Default behaviour is unchanged: ``min_input_len`` is 0."""
-
     def run(inp):
         question = path_prompt("Pick your path", input=inp, output=DummyOutput())
         completer = _resolve_completer(question.application.current_buffer.completer)


### PR DESCRIPTION
**What is the problem that this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes e.g. Closes #32 -->

Closes #359. `GreatUXPathCompleter` already accepts `min_input_len`, but the public `path()` prompt didn't expose it, so users had to construct their own completer to delay autocompletion (which reportedly gives a 20-30x speed up on Windows for slow filesystems).

**How did you solve it?**
<!-- A detailed description of your implementation. -->

Added a `min_input_len: int = 0` keyword argument to `questionary.path()` that is forwarded to the default `GreatUXPathCompleter`. Default is `0` so existing behaviour is unchanged.

**Checklist**
<!--- Put an `x` in all the boxes that apply. -->
<!-- Automated tests validate that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->

- [x] I have read the [Contributor's Guide](https://questionary.readthedocs.io/en/stable/pages/contributors.html#steps-for-submitting-code).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
