### PR TITLE
Wrap prompt messages to the terminal width

### DIFF
--- a/questionary/constants.py
+++ b/questionary/constants.py
@@ -27,6 +27,9 @@ INDICATOR_UNSELECTED = "○"
 # Prefix displayed in front of questions
 DEFAULT_QUESTION_PREFIX = "?"
 
+# Width assumed when the terminal size cannot be queried (no tty, etc.)
+DEFAULT_TERMINAL_WIDTH = 80
+
 # Message shown when a user aborts a question prompt using CTRL-C
 DEFAULT_KBI_MESSAGE = "\nCancelled by user\n"
 

--- a/questionary/prompts/autocomplete.py
+++ b/questionary/prompts/autocomplete.py
@@ -19,6 +19,7 @@ from prompt_toolkit.styles import Style
 
 from questionary.constants import DEFAULT_QUESTION_PREFIX
 from questionary.prompts.common import build_validator
+from questionary.prompts.common import format_question_tokens
 from questionary.question import Question
 from questionary.styles import merge_styles_default
 
@@ -178,7 +179,7 @@ def autocomplete(
     merged_style = merge_styles_default([style])
 
     def get_prompt_tokens() -> List[Tuple[str, str]]:
-        return [("class:qmark", qmark), ("class:question", " {} ".format(message))]
+        return format_question_tokens(qmark, message)
 
     def get_meta_style(meta: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         if meta:

--- a/questionary/prompts/checkbox.py
+++ b/questionary/prompts/checkbox.py
@@ -161,10 +161,7 @@ def checkbox(
     )
 
     def get_prompt_tokens() -> List[Tuple[str, str]]:
-        tokens = []
-
-        tokens.append(("class:qmark", qmark))
-        tokens.append(("class:question", " {} ".format(message)))
+        tokens = common.format_question_tokens(qmark, message)
 
         if ic.is_answered:
             nbr_selected = len(ic.selected_options)

--- a/questionary/prompts/common.py
+++ b/questionary/prompts/common.py
@@ -29,6 +29,7 @@ from questionary.constants import DEFAULT_STYLE
 from questionary.constants import INDICATOR_SELECTED
 from questionary.constants import INDICATOR_UNSELECTED
 from questionary.constants import INVALID_INPUT
+from questionary.utils import _wrap_message_to_terminal_width
 
 # This is a cut-down version of `prompt_toolkit.formatted_text.AnyFormattedText`
 # which does not exist in v2 of prompt_toolkit
@@ -556,6 +557,27 @@ class InquirerControl(FormattedTextControl):
             ),
             ("class:question-mark", "..."),
         ]
+
+
+def format_question_tokens(qmark: Optional[str], message: Any) -> List[Tuple[str, str]]:
+    """Build the leading formatted-text tokens for a prompt: the
+    question mark prefix (when qmark is given) followed by message.
+
+    The message is pre-wrapped to the current terminal width so long
+    help text wraps cleanly in narrow terminals; see
+    https://github.com/tmbo/questionary/issues/398.
+
+    Pass qmark=None to omit the prefix.
+    """
+    # qmark + leading separator space on the first line; just the
+    # leading space when there is no qmark.
+    prefix_width = (len(qmark) + 1) if qmark else 1
+    wrapped = _wrap_message_to_terminal_width(message, prefix_width=prefix_width)
+    tokens: List[Tuple[str, str]] = []
+    if qmark:
+        tokens.append(("class:qmark", qmark))
+    tokens.append(("class:question", f" {wrapped} "))
+    return tokens
 
 
 def build_validator(validate: Any) -> Optional[Validator]:

--- a/questionary/prompts/confirm.py
+++ b/questionary/prompts/confirm.py
@@ -12,6 +12,7 @@ from questionary.constants import NO
 from questionary.constants import NO_OR_YES
 from questionary.constants import YES
 from questionary.constants import YES_OR_NO
+from questionary.prompts.common import format_question_tokens
 from questionary.question import Question
 from questionary.styles import merge_styles_default
 
@@ -69,10 +70,7 @@ def confirm(
     status = {"answer": None, "complete": False}
 
     def get_prompt_tokens():
-        tokens = []
-
-        tokens.append(("class:qmark", qmark))
-        tokens.append(("class:question", " {} ".format(message)))
+        tokens = format_question_tokens(qmark, message)
 
         if instruction is not None:
             tokens.append(("class:instruction", instruction))

--- a/questionary/prompts/path.py
+++ b/questionary/prompts/path.py
@@ -22,6 +22,7 @@ from prompt_toolkit.styles import Style
 
 from questionary.constants import DEFAULT_QUESTION_PREFIX
 from questionary.prompts.common import build_validator
+from questionary.prompts.common import format_question_tokens
 from questionary.question import Question
 from questionary.styles import merge_styles_default
 
@@ -190,7 +191,7 @@ def path(
     merged_style = merge_styles_default([style])
 
     def get_prompt_tokens() -> List[Tuple[str, str]]:
-        return [("class:qmark", qmark), ("class:question", " {} ".format(message))]
+        return format_question_tokens(qmark, message)
 
     validator = build_validator(validate)
 

--- a/questionary/prompts/press_any_key_to_continue.py
+++ b/questionary/prompts/press_any_key_to_continue.py
@@ -7,6 +7,7 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.styles import Style
 
+from questionary.prompts.common import format_question_tokens
 from questionary.question import Question
 from questionary.styles import merge_styles_default
 
@@ -39,11 +40,7 @@ def press_any_key_to_continue(
         message = "Press any key to continue..."
 
     def get_prompt_tokens():
-        tokens = []
-
-        tokens.append(("class:question", f" {message} "))
-
-        return to_formatted_text(tokens)
+        return to_formatted_text(format_question_tokens(None, message))
 
     def exit_with_result(event):
         event.app.exit(result=None)

--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -176,7 +176,7 @@ def select(
 
     def get_prompt_tokens():
         # noinspection PyListCreation
-        tokens = [("class:qmark", qmark), ("class:question", " {} ".format(message))]
+        tokens = common.format_question_tokens(qmark, message)
 
         if ic.is_answered:
             if isinstance(ic.get_pointed_at().title, list):

--- a/questionary/prompts/text.py
+++ b/questionary/prompts/text.py
@@ -12,6 +12,7 @@ from prompt_toolkit.styles import Style
 from questionary.constants import DEFAULT_QUESTION_PREFIX
 from questionary.constants import INSTRUCTION_MULTILINE
 from questionary.prompts.common import build_validator
+from questionary.prompts.common import format_question_tokens
 from questionary.question import Question
 from questionary.styles import merge_styles_default
 
@@ -83,7 +84,7 @@ def text(
         instruction = INSTRUCTION_MULTILINE
 
     def get_prompt_tokens() -> List[Tuple[str, str]]:
-        result = [("class:qmark", qmark), ("class:question", " {} ".format(message))]
+        result = format_question_tokens(qmark, message)
         if instruction:
             result.append(("class:instruction", " {} ".format(instruction)))
         return result

--- a/questionary/utils.py
+++ b/questionary/utils.py
@@ -1,11 +1,100 @@
 import inspect
+import shutil
+import textwrap
 from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Set
 
+from prompt_toolkit.application.current import get_app_or_none
+
+from questionary.constants import DEFAULT_TERMINAL_WIDTH
+
 ACTIVATED_ASYNC_MODE = False
+
+
+def _current_terminal_width() -> int:
+    """Return the terminal width as currently seen by the renderer.
+
+    When called during a prompt-toolkit render pass, the running
+    Application knows the live screen size (it tracks SIGWINCH).
+    Querying it directly therefore returns a value that updates after a
+    terminal resize, while shutil.get_terminal_size may return stale
+    data if stdout has been replaced — which it is during a prompt
+    session.
+
+    Falls back to shutil.get_terminal_size outside of a prompt session
+    (e.g. unit tests), and to DEFAULT_TERMINAL_WIDTH if neither source
+    is usable.
+    """
+    app = get_app_or_none()
+    if app is not None:
+        columns = app.output.get_size().columns
+        if columns > 0:
+            return columns
+    try:
+        columns = shutil.get_terminal_size().columns
+    except (OSError, ValueError):
+        return DEFAULT_TERMINAL_WIDTH
+    return columns if columns > 0 else DEFAULT_TERMINAL_WIDTH
+
+
+def _wrap_message_to_terminal_width(message: Any, prefix_width: int = 0) -> Any:
+    """Wrap message to the current terminal width.
+
+    prompt-toolkit only line-wraps the input buffer window, not the
+    prompt text rendered above it. When a message contains a newline,
+    prompt-toolkit splits at the last newline and renders everything
+    before it in a non-wrapping window — long lines then overflow the
+    terminal width (see https://github.com/tmbo/questionary/issues/398).
+
+    Pre-wrapping each newline-separated paragraph of the message to the
+    terminal width sidesteps that: the rendered lines are already short
+    enough that wrapping is unnecessary.
+
+    Non-string messages (e.g. already-formatted text tuples) are
+    returned unchanged so callers passing pre-styled prompts are not
+    disturbed.
+
+    Args:
+        message: The user-provided message. Only plain str is wrapped;
+            other types pass through unchanged.
+        prefix_width: Number of cells reserved on the first line for any
+            prefix (e.g. the question mark plus a separating space).
+
+    Returns:
+        message with additional newlines inserted so that no line
+        exceeds the terminal width, or the original message unchanged
+        if it was not a plain string.
+    """
+    if not isinstance(message, str) or not message:
+        return message
+    width = _current_terminal_width()
+    # Pathologically narrow terminals: don't try to wrap, just hand the
+    # message back and let the terminal do its worst.
+    if width < 2:
+        return message
+    paragraphs = message.split("\n")
+    wrapped: List[str] = []
+    for i, paragraph in enumerate(paragraphs):
+        if not paragraph:
+            wrapped.append("")
+            continue
+        first = i == 0
+        paragraph_width = max(width - prefix_width, 1) if first else max(width, 1)
+        wrapped.append(
+            textwrap.fill(
+                paragraph,
+                width=paragraph_width,
+                break_long_words=False,
+                break_on_hyphens=False,
+                drop_whitespace=False,
+                replace_whitespace=False,
+            )
+            or paragraph
+        )
+    return "\n".join(wrapped)
 
 
 def is_prompt_toolkit_3() -> bool:

--- a/tests/prompts/test_common.py
+++ b/tests/prompts/test_common.py
@@ -14,6 +14,7 @@ from questionary import Choice
 from questionary.prompts import common
 from questionary.prompts.common import InquirerControl
 from questionary.prompts.common import build_validator
+from questionary.prompts.common import format_question_tokens
 from questionary.prompts.common import print_formatted_text
 from tests.utils import prompt_toolkit_version
 
@@ -284,3 +285,28 @@ def test_prompt_show_description():
     ]
     assert ic.pointed_at == 1
     assert ic._get_choice_tokens() == expected_tokens
+
+
+def test_format_question_tokens_with_qmark():
+    tokens = format_question_tokens("?", "What is your name?")
+    assert tokens == [
+        ("class:qmark", "?"),
+        ("class:question", " What is your name? "),
+    ]
+
+
+def test_format_question_tokens_omits_qmark_when_none():
+    tokens = format_question_tokens(None, "Press any key to continue...")
+    assert tokens == [
+        ("class:question", " Press any key to continue... "),
+    ]
+
+
+def test_format_question_tokens_passes_through_non_string_message():
+    formatted = [("class:question", "pre-styled")]
+    tokens = format_question_tokens("?", formatted)
+    # Non-string messages are not wrapped — they slot in as-is.
+    assert tokens == [
+        ("class:qmark", "?"),
+        ("class:question", f" {formatted} "),
+    ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,7 @@
+from unittest import mock
+
 from questionary import utils
+from questionary.constants import DEFAULT_TERMINAL_WIDTH
 
 
 def test_default_values_of():
@@ -95,3 +98,150 @@ def test_missing_arguments_of_no_args():
 
     defaults = utils.missing_arguments(f, {})
     assert defaults == set()
+
+
+def _fake_terminal_size(columns):
+    return mock.patch(
+        "questionary.utils._current_terminal_width",
+        return_value=columns,
+    )
+
+
+def test_wrap_message_to_terminal_width_short_string_unchanged():
+    with _fake_terminal_size(80):
+        assert utils._wrap_message_to_terminal_width("Hello") == "Hello"
+
+
+def test_wrap_message_to_terminal_width_long_string_wraps():
+    long_message = (
+        "Lorem ipsum dolor sit amet consetetur sadipscing elitr sed diam "
+        "nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam"
+    )
+    with _fake_terminal_size(40):
+        wrapped = utils._wrap_message_to_terminal_width(long_message)
+    assert "\n" in wrapped
+    for line in wrapped.split("\n"):
+        assert len(line) <= 40
+
+
+def test_wrap_message_to_terminal_width_preserves_existing_newlines():
+    message = "First paragraph short.\nSecond paragraph also short."
+    with _fake_terminal_size(80):
+        wrapped = utils._wrap_message_to_terminal_width(message)
+    assert wrapped == message
+
+
+def test_wrap_message_to_terminal_width_wraps_paragraph_after_newline():
+    """Regression test for https://github.com/tmbo/questionary/issues/398.
+
+    Long messages containing a trailing newline (as copier appends) must
+    still be wrapped to terminal width. Before the fix, prompt-toolkit split
+    on the last newline and rendered the leading paragraph in a non-wrapping
+    window, so long lines overflowed the terminal.
+    """
+    long_first = ("word " * 50).strip()  # 249 chars of breakable text
+    message = f"{long_first}\n"
+    with _fake_terminal_size(80):
+        wrapped = utils._wrap_message_to_terminal_width(message)
+    # No line in the first paragraph should exceed terminal width.
+    first_paragraph = wrapped.split("\n\n")[0] if "\n\n" in wrapped else wrapped
+    for line in first_paragraph.split("\n"):
+        assert len(line) <= 80
+
+
+def test_wrap_message_to_terminal_width_respects_prefix_width():
+    long_message = "word " * 30
+    with _fake_terminal_size(40):
+        wrapped = utils._wrap_message_to_terminal_width(long_message, prefix_width=10)
+    # First line wraps at width - prefix_width (40 - 10 = 30).
+    first_line = wrapped.split("\n")[0]
+    assert len(first_line) <= 30
+
+
+def test_wrap_message_to_terminal_width_passes_through_non_string():
+    formatted = [("class:question", "hello")]
+    assert utils._wrap_message_to_terminal_width(formatted) is formatted
+
+
+def test_wrap_message_to_terminal_width_passes_through_empty_string():
+    assert utils._wrap_message_to_terminal_width("") == ""
+
+
+def test_wrap_message_to_terminal_width_handles_unbreakable_long_word():
+    # `break_long_words=False` means a single very long word can't be split.
+    # The function should still return the message without crashing.
+    long_word = "a" * 200
+    with _fake_terminal_size(40):
+        wrapped = utils._wrap_message_to_terminal_width(long_word)
+    assert long_word in wrapped
+
+
+def test_current_terminal_width_falls_back_on_os_error():
+    with mock.patch(
+        "questionary.utils.shutil.get_terminal_size",
+        side_effect=OSError("no tty"),
+    ), mock.patch(
+        "questionary.utils.get_app_or_none",
+        return_value=None,
+    ):
+        assert utils._current_terminal_width() == DEFAULT_TERMINAL_WIDTH
+
+
+def test_wrap_message_to_terminal_width_falls_back_on_os_error():
+    with mock.patch(
+        "questionary.utils.shutil.get_terminal_size",
+        side_effect=OSError("no tty"),
+    ), mock.patch(
+        "questionary.utils.get_app_or_none",
+        return_value=None,
+    ):
+        # Falls back to DEFAULT_TERMINAL_WIDTH; a 200-char message should
+        # still wrap.
+        wrapped = utils._wrap_message_to_terminal_width("x " * 100)
+    assert "\n" in wrapped
+
+
+def test_current_terminal_width_prefers_active_app():
+    fake_app = mock.Mock()
+    fake_app.output.get_size.return_value = mock.Mock(columns=42, rows=24)
+    with mock.patch(
+        "questionary.utils.get_app_or_none",
+        return_value=fake_app,
+    ):
+        # Even with shutil reporting something else, the app's size wins.
+        with mock.patch(
+            "questionary.utils.shutil.get_terminal_size",
+            return_value=mock.Mock(columns=999, lines=24),
+        ):
+            assert utils._current_terminal_width() == 42
+
+
+def test_current_terminal_width_falls_through_when_app_reports_zero():
+    # An active app reporting 0 columns (degenerate) should not be trusted;
+    # the function falls through to shutil.
+    fake_app = mock.Mock()
+    fake_app.output.get_size.return_value = mock.Mock(columns=0, rows=24)
+    with mock.patch(
+        "questionary.utils.get_app_or_none",
+        return_value=fake_app,
+    ), mock.patch(
+        "questionary.utils.shutil.get_terminal_size",
+        return_value=mock.Mock(columns=120, lines=24),
+    ):
+        assert utils._current_terminal_width() == 120
+
+
+def test_current_terminal_width_falls_back_when_shutil_reports_zero():
+    with mock.patch(
+        "questionary.utils.get_app_or_none",
+        return_value=None,
+    ), mock.patch(
+        "questionary.utils.shutil.get_terminal_size",
+        return_value=mock.Mock(columns=0, lines=24),
+    ):
+        assert utils._current_terminal_width() == DEFAULT_TERMINAL_WIDTH
+
+
+def test_wrap_message_to_terminal_width_pathologically_narrow_returns_unchanged():
+    with _fake_terminal_size(1):
+        assert utils._wrap_message_to_terminal_width("hello world") == "hello world"


### PR DESCRIPTION
## Summary

Fixes [#398](https://github.com/tmbo/questionary/issues/398) — long prompt messages stop wrapping to terminal width when the message contains a newline.

This is the questionary side of [copier-org/copier#1764](https://github.com/copier-org/copier/issues/1764), which was closed pointing at #398. Copier appends `"\n "` to every prompt's message to push the cursor onto the next line, and the resulting newline trips the wrap-disabling code path described below.

## Root cause

In `prompt_toolkit/shortcuts/prompt.py`, `_split_multiline_prompt` splits the prompt at the **last** newline in the message. Everything before that newline is rendered in a separate above-input `Window`. That window is constructed with the default `wrap_lines=False`; only the input-buffer window receives `wrap_lines=True`:

```python
# main_input_container, abridged
HSplit([
    ConditionalContainer(
        Window(FormattedTextControl(get_prompt_text_1), dont_extend_height=True),
        Condition(has_before_fragments),
    ),
    ConditionalContainer(default_buffer_window, ...),  # wrap_lines=dyncond("wrap_lines")
    ...
])
```

So when a caller passes a message like `"long help text\n "`, prompt-toolkit puts "long help text" into the non-wrapping window and the long line overflows the terminal.

## Fix

Pre-wrap each `\n`-separated paragraph of the message to the current terminal width before constructing the formatted text. The rendered lines are then already short enough that prompt-toolkit's missing wrap on the above-input window doesn't matter.

Two internal helpers handle this:

- `_wrap_message_to_terminal_width(message, prefix_width)` in `questionary/utils.py` — the low-level primitive. Splits on `\n`, wraps each paragraph with `textwrap.fill` (no breaking of long words, no break-on-hyphens, preserves whitespace), returns the rewrapped string. Non-string messages (already-formatted tuples / lists) pass through unchanged so callers passing pre-styled prompts are not disturbed.
- `format_question_tokens(qmark, message)` in `questionary/prompts/common.py` — builds the leading `[("class:qmark", qmark), ("class:question", " message ")]` tuple list used by every built-in prompt. Owns the `prefix_width = len(qmark) + 1` arithmetic so prompt files don't have to know about it. With `qmark=None` it omits the qmark token and reduces to a question-only prompt.

Each prompt's `get_prompt_tokens` becomes a one-line call to `format_question_tokens`. Applied across the seven prompt types that format a user-provided message: `text`, `select`, `checkbox`, `confirm`, `autocomplete`, `path`, `press_any_key_to_continue`. `password` and `rawselect` delegate to `text` / `select` and inherit the fix transparently.

### Terminal width source

`_current_terminal_width()` queries the active `Application` via `get_app_or_none().output.get_size()` first — that value updates on SIGWINCH, so subsequent re-renders pick up the new width. Falls back to `shutil.get_terminal_size()` outside a prompt session (e.g. unit tests), and finally to `DEFAULT_TERMINAL_WIDTH` (80, defined in `questionary/constants.py`).

## Known limitation: rapid resize artifacts

This fix makes the prompt height **variable** with terminal width (1 line when wide, several when narrow). That exposes a pre-existing prompt-toolkit limitation around resize handling: `Application._on_resize` calls `renderer.erase()` then `_request_absolute_cursor_position()` then `_redraw()` — but the redraw fires before the async CPR response, so rapid SIGWINCH bursts can leave stale prior renders in the scrollback. The **final** render at any width is correct; only the intermediate frames during rapid resize are affected.

Without this fix the issue is hidden because every render is a single (cropped) line, so erase + redraw at the same height stays clean.

The proper fix for the resize race is upstream in prompt-toolkit's renderer / CPR handling; this PR doesn't attempt it.

## Tests

17 new unit tests.

`tests/test_utils.py` (14 tests on `_wrap_message_to_terminal_width` and `_current_terminal_width`):

- Short string returned unchanged
- Long string wraps at terminal width
- Existing newlines preserved as paragraph breaks
- Long paragraph followed by `\n` wraps (regression for #398)
- `prefix_width` reserves space on the first line
- Non-string messages pass through (regression for the `FormattedText` tuple case caught early in development)
- Empty string passes through
- Single very long word with no breakable whitespace returns unchanged (`textwrap` with `break_long_words=False`)
- Pathologically narrow terminal (1 col) returns unchanged
- `_current_terminal_width` falls back to `shutil` on no-app, then to `DEFAULT_TERMINAL_WIDTH` on `OSError`
- `_current_terminal_width` prefers the active app's size over `shutil`
- `_current_terminal_width` falls through to `shutil` when the app reports `columns=0`
- `_current_terminal_width` returns `DEFAULT_TERMINAL_WIDTH` when `shutil` reports `columns=0`

`tests/prompts/test_common.py` (3 tests on `format_question_tokens`):

- Builds the `[qmark, question]` token pair with the expected style classes
- Omits the qmark token when `qmark=None`
- Passes non-string messages through into the format string (preserving pre-existing behavior)

All 180 tests pass (163 pre-existing + 17 new).

## Contributor checklist

- `make test` — 180 tests pass
- `make lint` — pre-commit hooks pass (autoflake, black, isort, flake8)
- `make types` — mypy clean, no issues in 19 source files

## Manual verification

End-to-end test with copier (which is what surfaced the bug originally):

1. Created a venv with copier 9.15.1 + this branch installed editable.
2. Ran `copier copy` against a template with long help strings in a 60-col terminal.
3. **Before the fix:** help text cropped at terminal edge.
4. **After the fix:** help text wraps cleanly across multiple lines, each ≤ 60 cols.