### PR TITLE
fix: treat j/k as shortcuts in rawselect, not navigation

### DIFF
--- a/questionary/prompts/rawselect.py
+++ b/questionary/prompts/rawselect.py
@@ -75,5 +75,7 @@ def rawselect(
         style,
         use_shortcuts=True,
         use_arrow_keys=False,
+        use_jk_keys=False,
+        use_emacs_keys=False,
         **kwargs,
     )

--- a/tests/prompts/test_rawselect.py
+++ b/tests/prompts/test_rawselect.py
@@ -112,3 +112,15 @@ def test_select_ctr_c():
 
     with pytest.raises(KeyboardInterrupt):
         feed_cli_with_input("rawselect", message, text, **kwargs)
+
+
+def test_jk_keys_act_as_shortcuts_not_navigation():
+    # With 20 choices, "j" is auto-assigned as the shortcut for the 20th choice.
+    # In rawselect it must select that choice, not move the cursor down one
+    # (vim-style navigation), which is what happened before (issue #409).
+    message = "Foo message"
+    choices = [f"choice-{i}" for i in range(1, 21)]
+    text = "j" + KeyInputs.ENTER + "\r"
+
+    result, cli = feed_cli_with_input("rawselect", message, text, choices=choices)
+    assert result == "choice-20"


### PR DESCRIPTION
Fixes #409.

`rawselect` is shortcut-driven — it calls `select(...)` with `use_shortcuts=True, use_arrow_keys=False`. But it leaves `use_jk_keys` and `use_emacs_keys` at their default `True`. Once a prompt has enough choices, `j` and `k` are auto-assigned as choice shortcuts (`SHORTCUT_KEYS` includes them: `j` is the 20th, `k` the 21st). In `select`, the j/k navigation key bindings are registered after the per-choice shortcut bindings and are also `eager=True`, so navigation wins: pressing `j` moves the cursor down one instead of selecting the 20th choice.

Disabling `use_jk_keys`/`use_emacs_keys` in `rawselect` (consistent with the existing `use_arrow_keys=False`, since rawselect is shortcut-only) makes `j`/`k` behave as the shortcuts they were assigned.

Added `test_jk_keys_act_as_shortcuts_not_navigation` (20 choices, press `j` → expects `choice-20`). It fails on `master` (returns `choice-2`, the navigated-to row) and passes with the fix; the existing rawselect tests still pass.
