### PR TITLE
fix: don't render a select's default as a selected item

### DIFF
--- a/questionary/prompts/select.py
+++ b/questionary/prompts/select.py
@@ -164,7 +164,6 @@ def select(
 
     ic = InquirerControl(
         choices,
-        default,
         pointer=pointer,
         use_indicator=use_indicator,
         use_shortcuts=use_shortcuts,

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -4,7 +4,9 @@ from copy import copy
 import pytest
 
 from questionary import Choice
+from questionary import select
 from questionary import Separator
+from questionary.prompts.common import InquirerControl
 from tests.utils import KeyInputs
 from tests.utils import feed_cli_with_input
 from tests.utils import patched_prompt
@@ -508,3 +510,20 @@ def test_select_goes_back_to_top_after_filtering():
         **kwargs,
     )
     assert result == "jkl"
+
+
+def test_select_default_not_rendered_as_selected():
+    # Regression for #473: a single select must not mark its default as a
+    # persistently selected item. The default should only position the pointer
+    # (via initial_choice), not end up in selected_options (which renders with
+    # the inverted "class:selected" style).
+    question = select("Pick one", choices=["a", "b", "c"], default="b")
+    controls = [
+        c
+        for c in question.application.layout.find_all_controls()
+        if isinstance(c, InquirerControl)
+    ]
+    assert len(controls) == 1
+    ic = controls[0]
+    assert ic.selected_options == []
+    assert ic.get_pointed_at().value == "b"

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -4,8 +4,8 @@ from copy import copy
 import pytest
 
 from questionary import Choice
-from questionary import select
 from questionary import Separator
+from questionary import select
 from questionary.prompts.common import InquirerControl
 from tests.utils import KeyInputs
 from tests.utils import feed_cli_with_input

--- a/tests/prompts/test_select.py
+++ b/tests/prompts/test_select.py
@@ -2,12 +2,14 @@
 from copy import copy
 
 import pytest
+from prompt_toolkit.output import DummyOutput
 
 from questionary import Choice
 from questionary import Separator
 from questionary import select
 from questionary.prompts.common import InquirerControl
 from tests.utils import KeyInputs
+from tests.utils import execute_with_input_pipe
 from tests.utils import feed_cli_with_input
 from tests.utils import patched_prompt
 
@@ -517,13 +519,24 @@ def test_select_default_not_rendered_as_selected():
     # persistently selected item. The default should only position the pointer
     # (via initial_choice), not end up in selected_options (which renders with
     # the inverted "class:selected" style).
-    question = select("Pick one", choices=["a", "b", "c"], default="b")
-    controls = [
-        c
-        for c in question.application.layout.find_all_controls()
-        if isinstance(c, InquirerControl)
-    ]
-    assert len(controls) == 1
-    ic = controls[0]
-    assert ic.selected_options == []
-    assert ic.get_pointed_at().value == "b"
+    # Build the prompt with a pipe input + DummyOutput (like the other tests)
+    # so it does not require a real terminal.
+    def run(inp):
+        question = select(
+            "Pick one",
+            choices=["a", "b", "c"],
+            default="b",
+            input=inp,
+            output=DummyOutput(),
+        )
+        controls = [
+            c
+            for c in question.application.layout.find_all_controls()
+            if isinstance(c, InquirerControl)
+        ]
+        assert len(controls) == 1
+        ic = controls[0]
+        assert ic.selected_options == []
+        assert ic.get_pointed_at().value == "b"
+
+    execute_with_input_pipe(run)


### PR DESCRIPTION
Fixes #473.

In a single `select`, the `default` choice is rendered permanently with the inverted "selected" style, even when the cursor is on a different choice.

Root cause: `select()` passes `default` to `InquirerControl` twice — positionally **and** as `initial_choice`:

```python
ic = InquirerControl(
    choices,
    default,            # -> self.default -> _is_selected() -> selected_options
    ...
    initial_choice=default,   # -> pointer position
)
```

The positional `default` ends up in `selected_options`, which the renderer styles with `class:selected` regardless of the pointer position. But a single select has no persistent selection — only a pointer. `initial_choice=default` already places (and validates) the pointer, so the positional `default` only causes the buggy styling. The docstring also describes `default` solely as setting the pointer position.

Fix: drop the positional `default` from the `InquirerControl(...)` call, keeping `initial_choice=default`. (`checkbox` legitimately uses `selected_options`, so `_is_selected`/`common.py` are untouched.)

Added `test_select_default_not_rendered_as_selected`, which builds a `select` with a default and asserts the control's `selected_options` is empty while the pointer is on the default. It fails on `master` (selected_options contains the default) and passes with the fix; all existing `test_select.py` tests still pass.
